### PR TITLE
Add entrypoint to the pipeline, and default arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,4 @@ RUN conda env create -f ./environment.ubuntu.cpu.yml
 COPY src ./src
 COPY tests ./tests
 COPY *.ini ./
+COPY pipeline_config ./pipeline_config

--- a/pipeline_config/default.json
+++ b/pipeline_config/default.json
@@ -1,0 +1,10 @@
+{
+   "data":"data",
+   "export":{
+      "era5":[
+         {
+            "variable":"precipitation"
+         }
+      ]
+   }
+}

--- a/run.py
+++ b/run.py
@@ -1,0 +1,35 @@
+import argparse
+import json
+from pathlib import Path
+import os
+
+from src import Run, DictWithDefaults
+
+
+def main(input_args):
+
+    base_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+    default_config_file = base_dir / 'pipeline_config/default.json'
+
+    with open(default_config_file, 'r') as f:
+        default_config = json.load(f)
+
+    if input_args.config is not None:
+        with open(args.config, 'r') as f:
+            user_config = json.load(f)
+    else:
+        user_config = {}
+
+    config = DictWithDefaults(user_config, default_config)
+
+    data_path = Path(config['data'])
+    runtask = Run(data_path)
+    runtask.run(config)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Run the drought prediction pipeline')
+    parser.add_argument('--config', required=False,
+                        help='path to configuration file describing the pipeline to be run')
+    args = parser.parse_args()
+    main(args)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+from .run import Run, DictWithDefaults
+
+__all__ = ['Run', 'DictWithDefaults']

--- a/src/run.py
+++ b/src/run.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from typing import Dict
+
+from src.exporters import ERA5Exporter
+
+
+class DictWithDefaults:
+
+    def __init__(self, user_config: Dict, default_config: Dict) -> None:
+        self.user_config = user_config
+        self.default_config = default_config
+        self._check_keys()
+
+    def _check_keys(self) -> None:
+
+        # To be updated as the pipeline grows
+        expected_keys = {'data', 'export'}
+
+        for key in expected_keys:
+            try:
+                self.user_config[key]
+            except KeyError:
+                try:
+                    self.default_config[key]
+                except KeyError:
+                    assert False, f'{key} is not defined ' \
+                        f'in the user config or the default config. Try using ' \
+                        f'the default config in pipeline_config/default.json'
+
+    def __getitem__(self, key: str):
+
+        try:
+            return self.user_config[key]
+        except KeyError:
+            return self.default_config[key]
+
+
+class Run:
+    """Run the pipeline end to end
+
+    Attributes
+    ----------
+    data: pathlib.Path
+        The path to the data folder
+    """
+    def __init__(self, data: Path) -> None:
+        self.data = data
+
+    def export(self, export_args: Dict) -> None:
+        """Export the data
+
+        Arguments
+        ----------
+        export_args: dict
+            A dictionary of format {dataset: [{variable_1 arguments}, {variable_2 arguments]}
+            for all the variables to be exported
+        """
+
+        dataset2exporter = {
+            'era5': ERA5Exporter
+        }
+
+        for dataset, variables in export_args.items():
+            exporter = dataset2exporter[dataset](self.data)
+
+            for variable in variables:
+                _ = exporter.export(**variable)
+
+    def run(self, config: DictWithDefaults) -> None:
+
+        self.export(config['export'])

--- a/src/run.py
+++ b/src/run.py
@@ -62,6 +62,14 @@ class Run:
         }
 
         for dataset, variables in export_args.items():
+
+            # check the format is as we expected
+            assert dataset in dataset2exporter, \
+                f'{dataset} is not supported! Supported datasets are {dataset2exporter.keys()}'
+
+            assert type(variables) is list, \
+                f'Expected {dataset} values to be a list. Got {type(variables)} instead'
+
             exporter = dataset2exporter[dataset](self.data)
 
             for variable in variables:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,27 @@
+import pytest
+
+from src import DictWithDefaults
+
+
+class TestDictWithDefaults:
+
+    # This default dict needs to be updated as the
+    # actual default dict in pipeline_config/default.json
+    # is updated
+
+    default_dict = {"data": "data", "export": {"era5": [{"variable": "precipitation"}]}}
+
+    def test_missing_key(self):
+
+        config = {}
+        default_dict = self.default_dict.copy()
+        default_dict.pop('data', None)
+
+        with pytest.raises(Exception) as exception_info:
+            DictWithDefaults(config, default_dict)
+        print(default_dict)
+
+        error_message = 'data is not defined ' \
+                        'in the user config or the default config. Try using ' \
+                        'the default config in pipeline_config/default.json'
+        assert error_message in error_message, f'Got unexpected error message: {exception_info}'

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src import DictWithDefaults
+from src import Run, DictWithDefaults
 
 
 class TestDictWithDefaults:
@@ -19,9 +19,42 @@ class TestDictWithDefaults:
 
         with pytest.raises(Exception) as exception_info:
             DictWithDefaults(config, default_dict)
-        print(default_dict)
 
         error_message = 'data is not defined ' \
                         'in the user config or the default config. Try using ' \
                         'the default config in pipeline_config/default.json'
-        assert error_message in error_message, f'Got unexpected error message: {exception_info}'
+        assert error_message in str(exception_info), \
+            f'Got unexpected error message: {exception_info}'
+
+    def test_user_defined_priority(self):
+
+        user_config = {"data": "user_data"}
+
+        dict_with_defaults = DictWithDefaults(user_config, self.default_dict)
+
+        assert dict_with_defaults["data"] == user_config["data"], \
+            f'Expected data to be {user_config["data"]}, got {dict_with_defaults["data"]}'
+
+
+class TestRun:
+
+    def test_dataset_assertion(self, tmp_path):
+
+        runtask = Run(tmp_path)
+
+        export_dict = {"era42": ["towels"]}
+        with pytest.raises(Exception) as exception_info:
+            runtask.export(export_dict)
+        error_message_contains = 'is not supported! Supported datasets are'
+        assert error_message_contains in str(exception_info), \
+            f'Got unexpected error message: {exception_info}'
+
+    def test_dataset_values_assertion(self, tmp_path):
+        runtask = Run(tmp_path)
+
+        export_dict = {"era5": "not a list"}
+        with pytest.raises(Exception) as exception_info:
+            runtask.export(export_dict)
+        error_message_contains = 'values to be a list. Got'
+        assert error_message_contains in str(exception_info), \
+            f'Got unexpected error message: {exception_info}'


### PR DESCRIPTION
- [x] Add a `pipeline_config` folder where configurations from different pipelines can be run
- [x] Add a `default.json` file of default configurations, which are overriden by user-provided configurations
- [x] Add an entry point to the pipeline
- [x] Add tests (some added)