### PR TITLE
Dataloader

### DIFF
--- a/src/engineer/engineer.py
+++ b/src/engineer/engineer.py
@@ -236,4 +236,4 @@ class Engineer:
                 self.normalization_values[var]['mean'] = mean
                 self.normalization_values[var]['std'] = std
 
-            self.num_normalization_values += 1
+        self.num_normalization_values += 1

--- a/src/engineer/engineer.py
+++ b/src/engineer/engineer.py
@@ -142,7 +142,7 @@ class Engineer:
                           years: List[int],
                           target_variable: str,
                           pred_months: int = 11,
-                          expected_length: Optional[int] = 11,
+                          expected_length: Optional[int] = 11
                           ) -> xr.Dataset:
         years.sort()
 
@@ -173,7 +173,7 @@ class Engineer:
                     target_variable: str,
                     target_month: int,
                     pred_months: int,
-                    expected_length: Optional[int],
+                    expected_length: Optional[int]
                     ) -> Tuple[Optional[Dict[str, xr.Dataset]], date]:
 
         print(f'Generating data for year: {year}, target month: {target_month}')
@@ -229,11 +229,12 @@ class Engineer:
             mean = x_data[var].mean(dim=['lat', 'lon'], skipna=True).values
             std = x_data[var].std(dim=['lat', 'lon'], skipna=True).values
 
-            if var in self.normalization_values:
-                self.normalization_values[var]['mean'] += mean
-                self.normalization_values[var]['std'] += std
-            else:
-                self.normalization_values[var]['mean'] = mean
-                self.normalization_values[var]['std'] = std
+            if not (np.isnan(mean).any() or np.isnan(std).any()):
+                if var in self.normalization_values:
+                    self.normalization_values[var]['mean'] += mean
+                    self.normalization_values[var]['std'] += std
+                else:
+                    self.normalization_values[var]['mean'] = mean
+                    self.normalization_values[var]['std'] = std
 
         self.num_normalization_values += 1

--- a/src/engineer/engineer.py
+++ b/src/engineer/engineer.py
@@ -226,8 +226,8 @@ class Engineer:
     def calculate_normalization_values(self, x_data: xr.Dataset) -> None:
 
         for var in x_data.data_vars:
-            mean = x_data[var].mean(dim=['lat', 'lon']).values
-            std = x_data[var].std(dim=['lat', 'lon']).values
+            mean = x_data[var].mean(dim=['lat', 'lon'], skipna=True).values
+            std = x_data[var].std(dim=['lat', 'lon'], skipna=True).values
 
             if var in self.normalization_values:
                 self.normalization_values[var]['mean'] += mean

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -39,7 +39,7 @@ class ModelBase:
     def train(self) -> None:
         raise NotImplementedError
 
-    def predict(self) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
+    def predict(self) -> Tuple[Dict[str, Dict[str, np.ndarray]], Dict[str, np.ndarray]]:
         # This method should return the test arrays as loaded by
         # the test array dataloader, and the corresponding predictions
         raise NotImplementedError
@@ -65,7 +65,8 @@ class ModelBase:
         output_dict: Dict[str, int] = {}
         total_preds: List[np.ndarray] = []
         total_true: List[np.ndarray] = []
-        for key, true in test_arrays_dict.items():
+        for key, vals in test_arrays_dict.items():
+            true = vals['y']
             preds = preds_dict[key]
 
             output_dict[key] = np.sqrt(mean_squared_error(true, preds))
@@ -84,7 +85,7 @@ class ModelBase:
 
         if save_preds:
             for key, val in test_arrays_dict.items():
-                latlons = cast(np.ndarray, val.latlons)
+                latlons = cast(np.ndarray, val['latlons'])
                 preds = preds_dict[key]
 
                 if len(preds.shape) > 1:

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -1,22 +1,10 @@
 from pathlib import Path
-import pickle
 import numpy as np
 import json
-import xarray as xr
 import pandas as pd
-from dataclasses import dataclass
 from sklearn.metrics import mean_squared_error
 
 from typing import cast, Any, Dict, List, Optional, Tuple
-
-
-@dataclass
-class ModelArrays:
-    x: np.ndarray
-    y: np.ndarray
-    x_vars: List[str]
-    y_var: str
-    latlons: Optional[np.ndarray] = None
 
 
 class ModelBase:
@@ -30,8 +18,10 @@ class ModelBase:
     model_name: str  # to be added by the model classes
 
     def __init__(self, data_folder: Path = Path('data'),
-                 normalize_inputs: bool = True) -> None:
+                 normalize_inputs: bool = True,
+                 batch_size: int = 1) -> None:
 
+        self.batch_size = batch_size
         self.data_path = data_folder
         self.models_dir = data_folder / 'models'
         if not self.models_dir.exists():
@@ -54,9 +44,9 @@ class ModelBase:
     def train(self) -> None:
         raise NotImplementedError
 
-    def predict(self) -> Tuple[Dict[str, ModelArrays], Dict[str, np.ndarray]]:
+    def predict(self) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
         # This method should return the test arrays as loaded by
-        # load_test_arrays, and the corresponding predictions
+        # the test array dataloader, and the corresponding predictions
         raise NotImplementedError
 
     def save_model(self) -> None:
@@ -80,9 +70,8 @@ class ModelBase:
         output_dict: Dict[str, int] = {}
         total_preds: List[np.ndarray] = []
         total_true: List[np.ndarray] = []
-        for key, val in test_arrays_dict.items():
+        for key, true in test_arrays_dict.items():
             preds = preds_dict[key]
-            true = val.y
 
             output_dict[key] = np.sqrt(mean_squared_error(true, preds))
 
@@ -111,112 +100,3 @@ class ModelBase:
                     'lon': latlons[:, 1]}).set_index(['lat', 'lon']).to_xarray()
 
                 preds_xr.to_netcdf(self.model_dir / f'preds_{key}.nc')
-
-    def load_test_arrays(self) -> Dict[str, ModelArrays]:
-        test_data_path = self.data_path / 'features/test'
-
-        out_dict = {}
-        for subtrain in test_data_path.iterdir():
-            if (subtrain / 'x.nc').exists() and (subtrain / 'y.nc').exists():
-                modelarrays = self.ds_folder_to_np(subtrain, clear_nans=True,
-                                                   return_latlons=True)
-                modelarrays.x = self.normalize(modelarrays.x, 'test')
-                out_dict[subtrain.parts[-1]] = modelarrays
-        return out_dict
-
-    def load_train_arrays(self) -> Tuple[np.ndarray, np.ndarray]:
-        print('Loading training arrays')
-        train_data_path = self.data_path / 'features/train'
-
-        out_x, out_y = [], []
-        for subtrain in train_data_path.iterdir():
-            if (subtrain / 'x.nc').exists() and (subtrain / 'y.nc').exists():
-                arrays = self.ds_folder_to_np(subtrain, clear_nans=True,
-                                              return_latlons=False)
-                out_x.append(arrays.x)
-                out_y.append(arrays.y)
-        return (self.normalize(np.concatenate(out_x, axis=0), 'train'),
-                np.concatenate(out_y, axis=0))
-
-    @staticmethod
-    def ds_folder_to_np(folder: Path,
-                        clear_nans: bool = True,
-                        return_latlons: bool = False,
-                        ) -> ModelArrays:
-
-        x, y = xr.open_dataset(folder / 'x.nc'), xr.open_dataset(folder / 'y.nc')
-        assert len(list(y.data_vars)) == 1, f'Expect only 1 target variable!'
-        x_np, y_np = x.to_array().values, y.to_array().values
-
-        # first, x
-        x_np = x_np.reshape(x_np.shape[0], x_np.shape[1], x_np.shape[2] * x_np.shape[3])
-        x_np = np.moveaxis(np.moveaxis(x_np, 0, 1), -1, 0)
-        # then, y
-        y_np = y_np.reshape(y_np.shape[0], y_np.shape[1], y_np.shape[2] * y_np.shape[3])
-        y_np = np.moveaxis(y_np, -1, 0).reshape(-1, 1)
-
-        assert y_np.shape[0] == x_np.shape[0], f'x and y data have a different ' \
-            f'number of instances! x: {x_np.shape[0]}, y: {y_np.shape[0]}'
-
-        if clear_nans:
-            # remove nans if they are in the x or y data
-            x_nans, y_nans = np.isnan(x_np), np.isnan(y_np)
-
-            x_nans_summed = x_nans.reshape(x_nans.shape[0],
-                                           x_nans.shape[1] * x_nans.shape[2]).sum(axis=-1)
-            y_nans_summed = y_nans.sum(axis=-1)
-
-            notnan_indices = np.where((x_nans_summed == 0) & (y_nans_summed == 0))[0]
-            x_np, y_np = x_np[notnan_indices], y_np[notnan_indices]
-
-        if return_latlons:
-            lons, lats = np.meshgrid(x.lon.values, x.lat.values)
-            flat_lats, flat_lons = lats.reshape(-1, 1), lons.reshape(-1, 1)
-            latlons = np.concatenate((flat_lats, flat_lons), axis=-1)
-
-            if clear_nans:
-                latlons = latlons[notnan_indices]
-            return ModelArrays(x=x_np, y=y_np, x_vars=list(x.data_vars),
-                               y_var=list(y.data_vars)[0], latlons=latlons)
-
-        return ModelArrays(x=x_np, y=y_np, x_vars=list(x.data_vars),
-                           y_var=list(y.data_vars)[0])
-
-    def normalize(self, x_in: np.ndarray, mode: str) -> np.ndarray:
-
-        if not self.normalize_inputs:
-            return x_in
-
-        if self.normalizing_values is None:
-            if mode == 'test':
-                # we normalize using values from the training
-                # array
-                x_norm, _ = self.load_train_arrays()
-                self.normalizing_values = {
-                    'mean': np.mean(x_norm, axis=0),
-                    'std': np.std(x_norm, axis=0)
-                }
-            else:
-                self.normalizing_values = {
-                    'mean': np.mean(x_in, axis=0),
-                    'std': np.std(x_in, axis=0)
-                }
-            # automatically save the normalizing values
-            savepath = self.model_dir / 'normalizing_values.pkl'
-            with savepath.open('wb') as f:
-                pickle.dump(self.normalizing_values, f)
-
-        return (x_in - self.normalizing_values['mean']) / self.normalizing_values['std']
-
-    def load_normalizing_values(self) -> None:
-
-        savepath = self.model_dir / 'normalizing_values.pkl'
-        if savepath.exists():
-            with savepath.open('rb') as f:
-                self.normalizing_values = pickle.load(f)
-        else:
-            x_norm, _ = self.load_train_arrays()
-            self.normalizing_values = {
-                'mean': np.mean(x_norm, axis=0),
-                'std': np.std(x_norm, axis=0)
-            }

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -18,7 +18,6 @@ class ModelBase:
     model_name: str  # to be added by the model classes
 
     def __init__(self, data_folder: Path = Path('data'),
-                 normalize_inputs: bool = True,
                  batch_size: int = 1) -> None:
 
         self.batch_size = batch_size
@@ -36,10 +35,6 @@ class ModelBase:
 
         self.model: Any = None  # to be added by the model classes
         self.data_vars: Optional[List[str]] = None  # to be added by the train step
-
-        self.normalize_inputs = normalize_inputs
-        if self.normalize_inputs:
-            self.normalizing_values: Optional[Dict[str, np.ndarray]] = None
 
     def train(self) -> None:
         raise NotImplementedError

--- a/src/models/data.py
+++ b/src/models/data.py
@@ -1,0 +1,151 @@
+from dataclasses import dataclass
+import numpy as np
+from random import shuffle
+from pathlib import Path
+import xarray as xr
+
+from typing import Dict, Optional, List, Tuple
+
+
+@dataclass
+class ModelArrays:
+    x: np.ndarray
+    y: np.ndarray
+    x_vars: List[str]
+    y_var: str
+    latlons: Optional[np.ndarray] = None
+
+
+class DataLoader:
+    """Base class for the train and test dataloaders
+    """
+    def __init__(self, data_path: Path = Path('data'), batch_file_size: int = 1,
+                 mode: str = 'train', shuffle_data: bool = True,
+                 clear_nans: bool = True) -> None:
+
+        self.batch_file_size = batch_file_size
+        self.mode = mode
+        self.shuffle = shuffle_data
+        self.clear_nans = clear_nans
+        self.data_files = self._load_datasets(data_path, mode, shuffle_data)
+
+    def __iter__(self):
+        if self.mode == 'train':
+            return _TrainIter(self)
+        else:
+            return _TestIter(self)
+
+    def __len__(self) -> int:
+        return len(self.data_files) // self.batch_file_size
+
+    @staticmethod
+    def _load_datasets(data_path: Path, mode: str, shuffle_data: bool) -> List[Path]:
+
+        data_folder = data_path / f'features/{mode}'
+        output_paths: List[Path] = []
+
+        for subtrain in data_folder.iterdir():
+            if (subtrain / 'x.nc').exists() and (subtrain / 'y.nc').exists():
+                output_paths.append(subtrain)
+        if shuffle_data:
+            shuffle(output_paths)
+        return output_paths
+
+
+class _BaseIter:
+    """Base iterator
+    """
+    def __init__(self, loader: DataLoader) -> None:
+        self.data_files = loader.data_files
+        self.batch_file_size = loader.batch_file_size
+        self.shuffle = loader.shuffle
+        self.clear_nans = loader.clear_nans
+
+        self.idx = 0
+        self.max_idx = len(loader.data_files)
+
+    def __iter__(self):
+        return self
+
+    @staticmethod
+    def ds_folder_to_np(folder: Path,
+                        clear_nans: bool = True,
+                        return_latlons: bool = False,
+                        ) -> ModelArrays:
+
+        x, y = xr.open_dataset(folder / 'x.nc'), xr.open_dataset(folder / 'y.nc')
+        assert len(list(y.data_vars)) == 1, f'Expect only 1 target variable!'
+        x_np, y_np = x.to_array().values, y.to_array().values
+
+        # first, x
+        x_np = x_np.reshape(x_np.shape[0], x_np.shape[1], x_np.shape[2] * x_np.shape[3])
+        x_np = np.moveaxis(np.moveaxis(x_np, 0, 1), -1, 0)
+        # then, y
+        y_np = y_np.reshape(y_np.shape[0], y_np.shape[1], y_np.shape[2] * y_np.shape[3])
+        y_np = np.moveaxis(y_np, -1, 0).reshape(-1, 1)
+
+        assert y_np.shape[0] == x_np.shape[0], f'x and y data have a different ' \
+            f'number of instances! x: {x_np.shape[0]}, y: {y_np.shape[0]}'
+
+        if clear_nans:
+            # remove nans if they are in the x or y data
+            x_nans, y_nans = np.isnan(x_np), np.isnan(y_np)
+
+            x_nans_summed = x_nans.reshape(x_nans.shape[0],
+                                           x_nans.shape[1] * x_nans.shape[2]).sum(axis=-1)
+            y_nans_summed = y_nans.sum(axis=-1)
+
+            notnan_indices = np.where((x_nans_summed == 0) & (y_nans_summed == 0))[0]
+            x_np, y_np = x_np[notnan_indices], y_np[notnan_indices]
+
+        if return_latlons:
+            lons, lats = np.meshgrid(x.lon.values, x.lat.values)
+            flat_lats, flat_lons = lats.reshape(-1, 1), lons.reshape(-1, 1)
+            latlons = np.concatenate((flat_lats, flat_lons), axis=-1)
+
+            if clear_nans:
+                latlons = latlons[notnan_indices]
+            return ModelArrays(x=x_np, y=y_np, x_vars=list(x.data_vars),
+                               y_var=list(y.data_vars)[0], latlons=latlons)
+
+        return ModelArrays(x=x_np, y=y_np, x_vars=list(x.data_vars),
+                           y_var=list(y.data_vars)[0])
+
+
+class _TrainIter(_BaseIter):
+
+    def __next__(self) -> Tuple[np.ndarray, np.ndarray]:
+
+        if self.idx < self.max_idx:
+            out_x, out_y = [], []
+
+            cur_max_idx = min(self.idx + self.batch_file_size, self.max_idx)
+            for subfolder in self.data_files[self.idx: cur_max_idx]:
+                arrays = self.ds_folder_to_np(subfolder, clear_nans=self.clear_nans,
+                                              return_latlons=False)
+                out_x.append(arrays.x)
+                out_y.append(arrays.y)
+
+            self.idx = self.idx + self.batch_file_size
+            return np.concatenate(out_x, axis=0), np.concatenate(out_y, axis=0)
+        else:
+            raise StopIteration()
+
+
+class _TestIter(_BaseIter):
+
+    def __next__(self) -> Dict[str, ModelArrays]:
+
+        if self.idx < self.max_idx:
+            out_dict = {}
+
+            cur_max_idx = min(self.idx + self.batch_file_size, self.max_idx)
+            for subtrain in self.data_files[self.idx: cur_max_idx]:
+                modelarrays = self.ds_folder_to_np(subtrain, clear_nans=self.clear_nans,
+                                                   return_latlons=True)
+                out_dict[subtrain.parts[-1]] = modelarrays
+
+            self.idx = self.idx + self.batch_file_size
+            return out_dict
+        else:
+            raise StopIteration()

--- a/src/models/data.py
+++ b/src/models/data.py
@@ -18,7 +18,25 @@ class ModelArrays:
 
 
 class DataLoader:
-    """Base class for the train and test dataloaders
+    """Dataloader; lazily load the training and test data
+
+    Attributes:
+    ----------
+    data_path: Path = Path('data')
+        Location of the data folder
+    batch_file_size: int = 1
+        The number of files to load at a time
+    mode: str {'test', 'train'} = 'train'
+        Whether to load testing or training data. This also affects the way the data is
+        returned; for train, it is a concatenated array, but for test it is a dict with dates
+        so that the netcdf file can easily be reconstructed
+    shuffle_data: bool = True
+        Whether or not to shuffle data
+    clear_nans: bool = True
+        Whether to remove nan values
+    normalize: bool = True
+        Whether to normalize the data. This assumes a normalizing_dict.pkl was saved by the
+        engineer
     """
     def __init__(self, data_path: Path = Path('data'), batch_file_size: int = 1,
                  mode: str = 'train', shuffle_data: bool = True,

--- a/src/models/data.py
+++ b/src/models/data.py
@@ -17,6 +17,28 @@ class ModelArrays:
     latlons: Optional[np.ndarray] = None
 
 
+def train_val_mask(mask_len: int, val_ratio: float = 0.3) -> Tuple[List[bool], List[bool]]:
+    """Makes a trainining and validation mask which can be passed to the dataloader
+
+    Arguments
+    ----------
+    mask_len: int
+        The length of the mask to be created
+    val_ratio: float = 0.3
+        The ratio of instances which should be True for the val mask and False for the train
+        mask
+
+    Returns
+    ----------
+    The train mask and the val mask, both as lists
+    """
+    assert val_ratio < 1, f'Val ratio must be smaller than 1'
+    train_mask = np.random.rand(mask_len) < 1 - val_ratio
+    val_mask = ~train_mask
+
+    return train_mask.tolist(), val_mask.tolist()
+
+
 class DataLoader:
     """Dataloader; lazily load the training and test data
 
@@ -91,6 +113,10 @@ class _BaseIter:
         self.batch_file_size = loader.batch_file_size
         self.shuffle = loader.shuffle
         self.clear_nans = loader.clear_nans
+
+        if self.shuffle:
+            # makes sure they are shuffled every epoch
+            shuffle(self.data_files)
 
         self.normalizing_dict = loader.normalizing_dict
         self.normalizing_array: Optional[Dict[str, np.ndarray]] = None

--- a/src/models/parsimonious.py
+++ b/src/models/parsimonious.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import numpy as np
 
 from typing import Dict, Tuple
@@ -16,9 +15,6 @@ class Persistence(ModelBase):
 
     model_name = 'previous_month'
 
-    def __init__(self, data_folder: Path = Path('data')):
-        super().__init__(data_folder=data_folder, normalize_inputs=False)
-
     def train(self) -> None:
         pass
 
@@ -28,7 +24,7 @@ class Persistence(ModelBase):
     def predict(self) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
 
         test_arrays_loader = DataLoader(data_path=self.data_path, batch_file_size=self.batch_size,
-                                        shuffle_data=False, mode='test')
+                                        shuffle_data=False, mode='test', normalize=False)
 
         preds_dict: Dict[str, np.ndarray] = {}
         test_arrays_dict: Dict[str, np.ndarray] = {}

--- a/src/models/parsimonious.py
+++ b/src/models/parsimonious.py
@@ -21,13 +21,13 @@ class Persistence(ModelBase):
     def save_model(self) -> None:
         print('Move on! Nothing to save here!')
 
-    def predict(self) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
+    def predict(self) -> Tuple[Dict[str, Dict[str, np.ndarray]], Dict[str, np.ndarray]]:
 
         test_arrays_loader = DataLoader(data_path=self.data_path, batch_file_size=self.batch_size,
                                         shuffle_data=False, mode='test', normalize=False)
 
         preds_dict: Dict[str, np.ndarray] = {}
-        test_arrays_dict: Dict[str, np.ndarray] = {}
+        test_arrays_dict: Dict[str, Dict[str, np.ndarray]] = {}
         for dict in test_arrays_loader:
             for key, val in dict.items():
                 try:
@@ -37,6 +37,6 @@ class Persistence(ModelBase):
                     raise e
 
                 preds_dict[key] = val.x[:, -1, [target_idx]]
-                test_arrays_dict[key] = val.y
+                test_arrays_dict[key] = {'y': val.y, 'latlons': val.latlons}
 
         return test_arrays_dict, preds_dict

--- a/src/models/regression.py
+++ b/src/models/regression.py
@@ -38,13 +38,13 @@ class LinearRegression(ModelBase):
         coefs = self.model.coef_
         np.save(self.model_dir / 'model.npy', coefs)
 
-    def predict(self) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
+    def predict(self) -> Tuple[Dict[str, Dict[str, np.ndarray]], Dict[str, np.ndarray]]:
 
         test_arrays_loader = DataLoader(data_path=self.data_path, batch_file_size=self.batch_size,
                                         shuffle_data=False, mode='test')
 
         preds_dict: Dict[str, np.ndarray] = {}
-        test_arrays_dict: Dict[str, np.ndarray] = {}
+        test_arrays_dict: Dict[str, Dict[str, np.ndarray]] = {}
 
         if self.model is None:
             self.train()
@@ -55,6 +55,6 @@ class LinearRegression(ModelBase):
                 preds = self.model.predict(val.x.reshape(val.x.shape[0],
                                                          val.x.shape[1] * val.x.shape[2]))
                 preds_dict[key] = preds
-                test_arrays_dict[key] = val.y
+                test_arrays_dict[key] = {'y': val.y, 'latlons': val.latlons}
 
         return test_arrays_dict, preds_dict

--- a/src/models/regression.py
+++ b/src/models/regression.py
@@ -1,33 +1,76 @@
 import numpy as np
+from pathlib import Path
 from sklearn import linear_model
 from sklearn.metrics import mean_squared_error
 
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 
 from .base import ModelBase
-from .data import DataLoader
+from .data import DataLoader, train_val_mask
 
 
 class LinearRegression(ModelBase):
 
     model_name = 'linear_regression'
 
+    def __init__(self, data_folder: Path = Path('data'),
+                 batch_size: int = 1, num_epochs: int = 1,
+                 early_stopping: Optional[int] = None) -> None:
+        super().__init__(data_folder, batch_size)
+
+        self.num_epochs = num_epochs
+        self.early_stopping = early_stopping
+
     def train(self) -> None:
         print(f'Training {self.model_name}')
 
-        train_dataloader = DataLoader(data_path=self.data_path, batch_file_size=self.batch_size,
-                                      shuffle_data=True, mode='train')
+        if self.early_stopping is not None:
+            len_mask = len(DataLoader._load_datasets(self.data_path, mode='train',
+                                                     shuffle_data=False))
+            train_mask, val_mask = train_val_mask(len_mask, 0.3)
+
+            train_dataloader = DataLoader(data_path=self.data_path,
+                                          batch_file_size=self.batch_size,
+                                          shuffle_data=True, mode='train', mask=train_mask)
+            val_dataloader = DataLoader(data_path=self.data_path,
+                                        batch_file_size=self.batch_size,
+                                        shuffle_data=False, mode='train', mask=val_mask)
+            batches_without_improvement = 0
+            best_val_score = np.inf
+        else:
+            train_dataloader = DataLoader(data_path=self.data_path,
+                                          batch_file_size=self.batch_size,
+                                          shuffle_data=True, mode='train')
         self.model: linear_model.SGDRegressor = linear_model.SGDRegressor()
 
-        for x, y in train_dataloader:
-            x = x.reshape(x.shape[0], x.shape[1] * x.shape[2])
+        for epoch in range(self.num_epochs):
+            train_rmse = []
+            for x, y in train_dataloader:
+                x = x.reshape(x.shape[0], x.shape[1] * x.shape[2])
+                self.model.partial_fit(x, y.ravel())
 
-            self.model.partial_fit(x, y.ravel())
+                train_pred_y = self.model.predict(x)
+                train_rmse.append(np.sqrt(mean_squared_error(y, train_pred_y)))
+            if self.early_stopping is not None:
+                val_rmse = []
+                for x, y in val_dataloader:
+                    x = x.reshape(x.shape[0], x.shape[1] * x.shape[2])
+                    val_pred_y = self.model.predict(x)
+                    val_rmse.append(np.sqrt(mean_squared_error(y, val_pred_y)))
 
-            train_pred_y = self.model.predict(x)
-            train_rmse = np.sqrt(mean_squared_error(y, train_pred_y))
+            print(f'Epoch {epoch + 1}, train RMSE: {np.mean(train_rmse)}')
 
-            print(f'Train set RMSE: {train_rmse}')
+            if self.early_stopping is not None:
+                epoch_val_rmse = np.mean(val_rmse)
+                print(f'Val RMSE: {epoch_val_rmse}')
+                if epoch_val_rmse < best_val_score:
+                    batches_without_improvement = 0
+                    best_val_score = epoch_val_rmse
+                else:
+                    batches_without_improvement += 1
+                    if batches_without_improvement == self.early_stopping:
+                        print('Early stopping!')
+                        return None
 
     def save_model(self) -> None:
 

--- a/src/models/regression.py
+++ b/src/models/regression.py
@@ -22,7 +22,7 @@ class LinearRegression(ModelBase):
         for x, y in train_dataloader:
             x = x.reshape(x.shape[0], x.shape[1] * x.shape[2])
 
-            self.model.partial_fit(x, y)
+            self.model.partial_fit(x, y.ravel())
 
             train_pred_y = self.model.predict(x)
             train_rmse = np.sqrt(mean_squared_error(y, train_pred_y))

--- a/tests/engineer/test_engineer.py
+++ b/tests/engineer/test_engineer.py
@@ -77,17 +77,11 @@ class TestEngineer:
         dataset, _, _ = _make_dataset(size=(2, 2))
 
         engineer = Engineer(tmp_path)
-        train, test = engineer._train_test_split(dataset, years=[2001],
-                                                 target_variable='VHI')
+        train = engineer._train_test_split(dataset, years=[2001],
+                                           target_variable='VHI')
 
         assert (train.time.values < np.datetime64('2001-01-01')).all(), \
             'Got years greater than the test year in the training set!'
-
-        assert len(test[2001]) == 12, f'Expected 12 testing months in the test dataset'
-
-        for dataset in {'x', 'y'}:
-            assert (test[2001][12][dataset].time.values > np.datetime64('2000-12-31')).all(), \
-                'Got years smaller than the test year in the test set!'
 
     def test_engineer(self, tmp_path):
 

--- a/tests/engineer/test_engineer.py
+++ b/tests/engineer/test_engineer.py
@@ -117,7 +117,7 @@ class TestEngineer:
 
         for key, val in norm_dict.items():
             assert key in {'a', 'b'}, f'Unexpected key!'
-            assert np.count_nonzero(norm_dict[key]['mean']) == 0, \
+            assert (norm_dict[key]['mean'] == 1).all(), \
                 f'Mean incorrectly calculated!'
-            assert np.count_nonzero(norm_dict[key]['std']) == 0, \
+            assert (norm_dict[key]['std'] == 0).all(), \
                 f'Std incorrectly calculated!'

--- a/tests/engineer/test_engineer.py
+++ b/tests/engineer/test_engineer.py
@@ -1,4 +1,5 @@
 import pytest
+import pickle
 import numpy as np
 import xarray as xr
 
@@ -19,7 +20,7 @@ class TestEngineer:
             (interim_folder / f'{var}_preprocessed').mkdir()
 
             # this file should be captured
-            data, _, _ = _make_dataset((10, 10), var)
+            data, _, _ = _make_dataset((10, 10), var, const=True)
             filename = interim_folder / f'{var}_preprocessed/hello.nc'
             data.to_netcdf(filename)
 
@@ -108,3 +109,15 @@ class TestEngineer:
 
         assert len(list((tmp_path / 'features/train').glob('2001_*'))) == 0, \
             'Test data in the training data!'
+
+        assert (tmp_path / 'features/normalizing_dict.pkl').exists(), \
+            f'Normalizing dict not saved!'
+        with (tmp_path / 'features/normalizing_dict.pkl').open('rb') as f:
+            norm_dict = pickle.load(f)
+
+        for key, val in norm_dict.items():
+            assert key in {'a', 'b'}, f'Unexpected key!'
+            assert np.count_nonzero(norm_dict[key]['mean']) == 0, \
+                f'Mean incorrectly calculated!'
+            assert np.count_nonzero(norm_dict[key]['std']) == 0, \
+                f'Std incorrectly calculated!'

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -15,7 +15,7 @@ class TestBase:
 
             y = np.array([1, 1, 1, 1, 1])
 
-            test_arrays = {'hello': y}
+            test_arrays = {'hello': {'y': y}}
             preds_arrays = {'hello': y}
 
             return test_arrays, preds_arrays

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,8 +1,6 @@
 import numpy as np
 
-from src.models.base import ModelBase, ModelArrays
-
-from ..utils import _make_dataset
+from src.models.base import ModelBase
 
 
 class TestBase:
@@ -11,48 +9,13 @@ class TestBase:
         ModelBase(tmp_path)
         assert (tmp_path / 'models').exists(), f'Models dir not made!'
 
-    def test_ds_to_np(self, tmp_path):
-
-        x, _, _ = _make_dataset(size=(5, 5))
-        y, _, _ = _make_dataset(size=(5, 5))
-        y = y.isel(time=[0])
-
-        x.to_netcdf(tmp_path / 'x.nc')
-        y.to_netcdf(tmp_path / 'y.nc')
-
-        arrays = ModelBase.ds_folder_to_np(tmp_path, return_latlons=True)
-
-        x_np, y_np, latlons = arrays.x, arrays.y, arrays.latlons
-
-        assert x_np.shape[0] == y_np.shape[0] == latlons.shape[0], \
-            f'x, y and latlon data have a different number of instances! ' \
-            f'x: {x_np.shape[0]}, y: {y_np.shape[0]}, latlons: {latlons.shape[0]}'
-
-        for idx in range(latlons.shape[0]):
-
-            lat, lon = latlons[idx, 0], latlons[idx, 1]
-
-            for time in range(x_np.shape[1]):
-                target = x.isel(time=time).sel(lat=lat).sel(lon=lon).VHI.values
-
-                assert target == x_np[idx, time, 0], \
-                    f'Got different x values for time idx: {time}, lat: {lat}, ' \
-                    f'lon: {lon}.Expected {target}, got {x_np[idx, time, 0]}'
-
-            target_y = y.isel(time=0).sel(lat=lat).sel(lon=lon).VHI.values
-            assert target_y == y_np[idx, 0], \
-                f'Got y different values for lat: {lat}, ' \
-                f'lon: {lon}.Expected {target_y}, got {y_np[idx, 0]}'
-
     def test_evaluate(self, tmp_path, monkeypatch, capsys):
 
         def mockreturn(self):
 
-            x = np.array([1, 1, 1, 1, 1])
             y = np.array([1, 1, 1, 1, 1])
 
-            test_arrays = {'hello': ModelArrays(x=x, y=y, x_vars=['foo'],
-                                                y_var='bar')}
+            test_arrays = {'hello': y}
             preds_arrays = {'hello': y}
 
             return test_arrays, preds_arrays
@@ -66,35 +29,3 @@ class TestBase:
         expected_stdout = 'RMSE: 0.0'
         assert expected_stdout in captured.out, \
             f'Expected stdout to be {expected_stdout}, got {captured.out}'
-
-    def test_normalizing(self, tmp_path):
-
-        base = ModelBase(tmp_path)
-        base.model_dir = base.models_dir / 'base'
-        base.model_dir.mkdir(parents=True)
-
-        # batch_size = 100, timesteps = 11, n_features = 2
-        array_shape = (100, 11, 2)
-        test_array = np.ones(array_shape)
-
-        normalized = base.normalize(test_array, mode='train')
-
-        assert normalized.shape == array_shape, f'Normalizing changed the shape of the array!'
-        assert base.normalizing_values is not None, \
-            f'Normalizing values not assigned in the model!'
-        assert (base.normalizing_values['mean'] == np.mean(test_array, axis=0)).all()
-        assert (base.normalizing_values['std'] == np.std(test_array, axis=0)).all()
-
-        # finally, we check its been saved
-        assert (base.model_dir / 'normalizing_values.pkl').exists(), \
-            f'Normalizing dict not saved!'
-
-        # then, we check it loads properly
-        expected_vals = base.normalizing_values
-        base.normalizing_values = None
-        assert base.normalizing_values is None  # This is just to make sure the next test works
-
-        base.load_normalizing_values()
-        for key, val in expected_vals.items():
-            assert (base.normalizing_values[key] == val).all(), \
-                f'Normalizing dict not properly loaded!'

--- a/tests/models/test_data.py
+++ b/tests/models/test_data.py
@@ -1,11 +1,29 @@
 import pytest
 
-from src.models.data import _BaseIter
+from src.models.data import DataLoader, _BaseIter
 
 from ..utils import _make_dataset
 
 
 class TestBaseIter:
+
+    def test_mask(self, tmp_path):
+
+        for i in range(5):
+            (tmp_path / f'features/train/{i}').mkdir(parents=True)
+            (tmp_path / f'features/train/{i}/x.nc').touch()
+            (tmp_path / f'features/train/{i}/y.nc').touch()
+
+        mask_train = [True, True, False, True, False]
+        mask_val = [False, False, True, False, True]
+
+        train_paths = DataLoader._load_datasets(tmp_path, mode='train',
+                                                shuffle_data=True, mask=mask_train)
+        val_paths = DataLoader._load_datasets(tmp_path, mode='train',
+                                              shuffle_data=True, mask=mask_val)
+        assert len(set(train_paths).intersection(set(val_paths))) == 0, \
+            f'Got the same file in both train and val set!'
+        assert len(train_paths) + len(val_paths) == 5, f'Not all files loaded!'
 
     @pytest.mark.parametrize('normalize', [True, False])
     def test_ds_to_np(self, tmp_path, normalize):

--- a/tests/models/test_data.py
+++ b/tests/models/test_data.py
@@ -1,0 +1,39 @@
+from src.models.data import _BaseIter
+
+from ..utils import _make_dataset
+
+
+class TestBaseIter:
+
+    def test_ds_to_np(self, tmp_path):
+
+        x, _, _ = _make_dataset(size=(5, 5))
+        y, _, _ = _make_dataset(size=(5, 5))
+        y = y.isel(time=[0])
+
+        x.to_netcdf(tmp_path / 'x.nc')
+        y.to_netcdf(tmp_path / 'y.nc')
+
+        arrays = _BaseIter.ds_folder_to_np(tmp_path, return_latlons=True)
+
+        x_np, y_np, latlons = arrays.x, arrays.y, arrays.latlons
+
+        assert x_np.shape[0] == y_np.shape[0] == latlons.shape[0], \
+            f'x, y and latlon data have a different number of instances! ' \
+            f'x: {x_np.shape[0]}, y: {y_np.shape[0]}, latlons: {latlons.shape[0]}'
+
+        for idx in range(latlons.shape[0]):
+
+            lat, lon = latlons[idx, 0], latlons[idx, 1]
+
+            for time in range(x_np.shape[1]):
+                target = x.isel(time=time).sel(lat=lat).sel(lon=lon).VHI.values
+
+                assert target == x_np[idx, time, 0], \
+                    f'Got different x values for time idx: {time}, lat: {lat}, ' \
+                    f'lon: {lon}.Expected {target}, got {x_np[idx, time, 0]}'
+
+            target_y = y.isel(time=0).sel(lat=lat).sel(lon=lon).VHI.values
+            assert target_y == y_np[idx, 0], \
+                f'Got y different values for lat: {lat}, ' \
+                f'lon: {lon}.Expected {target_y}, got {y_np[idx, 0]}'

--- a/tests/models/test_parsimonious.py
+++ b/tests/models/test_parsimonious.py
@@ -1,33 +1,24 @@
-import numpy as np
-
 from src.models.parsimonious import Persistence
-from src.models.base import ModelArrays
+
+from ..utils import _make_dataset
 
 
 class TestPersistence:
 
-    def test_predict(self, tmp_path, monkeypatch):
+    def test_predict(self, tmp_path):
 
-        batch_size, timesteps, vars = 5, 6, 2
+        x, _, _ = _make_dataset(size=(5, 5))
+        y = x.isel(time=[-1])
 
-        def mockreturn(self):
-            x = np.ones((batch_size, timesteps, vars))
-            print(x.shape)
-            x[:, -1, :] *= 2
+        test_features = tmp_path / 'features/test/hello'
+        test_features.mkdir(parents=True)
 
-            x_vars = ['VHI', 'precip']
-            y = np.ones((batch_size, 1))
-            y_var = 'VHI'
-
-            return {'hello': ModelArrays(x=x, x_vars=x_vars, y=y, y_var=y_var)}
-
-        monkeypatch.setattr(Persistence, 'load_test_arrays', mockreturn)
+        x.to_netcdf(test_features / 'x.nc')
+        y.to_netcdf(test_features / 'y.nc')
 
         predictor = Persistence(tmp_path)
 
         test_arrays, preds = predictor.predict()
 
-        assert preds['hello'].shape == (batch_size, 1), \
-            f'Wrong sized predictions! Got {preds["hello"].shape}, expected ({batch_size}, 1)'
-
-        assert (preds['hello'] == 2).all(), f'Expected all values to be 2!'
+        assert (test_arrays['hello'] == preds['hello']).all(), \
+            f'Last timestep not correctly taken!'

--- a/tests/models/test_parsimonious.py
+++ b/tests/models/test_parsimonious.py
@@ -20,5 +20,5 @@ class TestPersistence:
 
         test_arrays, preds = predictor.predict()
 
-        assert (test_arrays['hello'] == preds['hello']).all(), \
+        assert (test_arrays['hello']['y'] == preds['hello']).all(), \
             f'Last timestep not correctly taken!'

--- a/tests/models/test_regression.py
+++ b/tests/models/test_regression.py
@@ -51,6 +51,9 @@ class TestLinearRegression:
         model.train()
 
         captured = capsys.readouterr()
+        # Because the y data is the last timestep of the x data, and the normalization
+        # leaves the values unchanged, the model should have a perfect RMSE. If it doesn't,
+        # something has probably been broken (e.g. by weird array broadcasting)
         expected_stdout = 'Train set RMSE: 0.0'
         assert expected_stdout in captured.out, \
             f'Expected stdout to be {expected_stdout}, got {captured.out}'

--- a/tests/models/test_regression.py
+++ b/tests/models/test_regression.py
@@ -3,6 +3,8 @@ import numpy as np
 from sklearn import linear_model
 from src.models import LinearRegression
 
+from ..utils import _make_dataset
+
 
 class TestLinearRegression:
 
@@ -28,15 +30,15 @@ class TestLinearRegression:
         saved_model = np.load(tmp_path / 'models/linear_regression/model.npy')
         assert np.array_equal(model_array, saved_model), f'Different array saved!'
 
-    def test_train(self, tmp_path, monkeypatch, capsys):
+    def test_train(self, tmp_path, capsys):
+        x, _, _ = _make_dataset(size=(5, 5), const=True)
+        y = x.isel(time=[-1])
 
-        y = np.array([1, 1, 1, 1, 1])
-        x = np.expand_dims(np.expand_dims(y, 1), 1)
+        test_features = tmp_path / 'features/train/hello'
+        test_features.mkdir(parents=True)
 
-        def mockloadtrain(self):
-            return x, y
-
-        monkeypatch.setattr(LinearRegression, 'load_train_arrays', mockloadtrain)
+        x.to_netcdf(test_features / 'x.nc')
+        y.to_netcdf(test_features / 'y.nc')
 
         model = LinearRegression(tmp_path)
         model.train()
@@ -46,5 +48,5 @@ class TestLinearRegression:
         assert expected_stdout in captured.out, \
             f'Expected stdout to be {expected_stdout}, got {captured.out}'
 
-        assert type(model.model) == linear_model.LinearRegression, \
+        assert type(model.model) == linear_model.SGDRegressor, \
             f'Model attribute not a linear regression!'

--- a/tests/models/test_regression.py
+++ b/tests/models/test_regression.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pickle
 
 from sklearn import linear_model
 from src.models import LinearRegression
@@ -36,6 +37,12 @@ class TestLinearRegression:
 
         test_features = tmp_path / 'features/train/hello'
         test_features.mkdir(parents=True)
+
+        norm_dict = {'VHI': {'mean': np.zeros(x.to_array().values.shape[:2]),
+                             'std': np.ones(x.to_array().values.shape[:2])}
+                     }
+        with (tmp_path / 'features/normalizing_dict.pkl').open('wb') as f:
+            pickle.dump(norm_dict, f)
 
         x.to_netcdf(test_features / 'x.nc')
         y.to_netcdf(test_features / 'y.nc')

--- a/tests/models/test_regression.py
+++ b/tests/models/test_regression.py
@@ -51,10 +51,7 @@ class TestLinearRegression:
         model.train()
 
         captured = capsys.readouterr()
-        # Because the y data is the last timestep of the x data, and the normalization
-        # leaves the values unchanged, the model should have a perfect RMSE. If it doesn't,
-        # something has probably been broken (e.g. by weird array broadcasting)
-        expected_stdout = 'Train set RMSE: 0.0'
+        expected_stdout = 'Epoch 1, train RMSE: 0.'
         assert expected_stdout in captured.out, \
             f'Expected stdout to be {expected_stdout}, got {captured.out}'
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ import xarray as xr
 
 
 def _make_dataset(size, variable_name='VHI', lonmin=-180.0, lonmax=180.0,
-                  latmin=-55.152, latmax=75.024, add_times=True):
+                  latmin=-55.152, latmax=75.024, add_times=True, const=False):
 
     lat_len, lon_len = size
     # create the vector
@@ -21,6 +21,8 @@ def _make_dataset(size, variable_name='VHI', lonmin=-180.0, lonmax=180.0,
         dims.insert(0, 'time')
         coords['time'] = times
     var = np.random.randint(100, size=size)
+    if const:
+        var *= 0
 
     ds = xr.Dataset({variable_name: (dims, var)}, coords=coords)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,6 +23,7 @@ def _make_dataset(size, variable_name='VHI', lonmin=-180.0, lonmax=180.0,
     var = np.random.randint(100, size=size)
     if const:
         var *= 0
+        var += 1
 
     ds = xr.Dataset({variable_name: (dims, var)}, coords=coords)
 


### PR DESCRIPTION
Resolves #38 

Adds a dataloader so that data will only be loaded into memory when necessary. A few additional notes:

- Normalizing values are now calculated in the engineer, since the full dataset is never loaded into memory
- The linear regression now uses SGD (instead of ordinary least squares) since everything happens in minibatches
- Functionality to make training and validation sets, for early stopping (with early stopping optionally implemented in the linear regression as an example)

Tested with unit tests, as well as by training the linear regression model using VHI, CHIRPS precip and GLEAM (`E`, `SMroot` and `SMsurf`) data, with and without early stopping