### PR TITLE
Revert to best model during early stopping

### DIFF
--- a/src/models/linear_network.py
+++ b/src/models/linear_network.py
@@ -130,10 +130,12 @@ class LinearNetwork(ModelBase):
                 if epoch_val_rmse < best_val_score:
                     batches_without_improvement = 0
                     best_val_score = epoch_val_rmse
+                    best_model_dict = self.model.state_dict()
                 else:
                     batches_without_improvement += 1
                     if batches_without_improvement == early_stopping:
                         print('Early stopping!')
+                        self.model.load_state_dict(best_model_dict)
                         return None
 
     def predict(self) -> Tuple[Dict[str, Dict[str, np.ndarray]], Dict[str, np.ndarray]]:

--- a/src/models/regression.py
+++ b/src/models/regression.py
@@ -72,10 +72,14 @@ class LinearRegression(ModelBase):
                 if epoch_val_rmse < best_val_score:
                     batches_without_improvement = 0
                     best_val_score = epoch_val_rmse
+                    best_coef = self.model.coef_
+                    best_intercept = self.model.intercept_
                 else:
                     batches_without_improvement += 1
                     if batches_without_improvement == early_stopping:
                         print('Early stopping!')
+                        self.model.coef_ = best_coef
+                        self.model.intercept_ = best_intercept
                         return None
 
     def explain(self, x: Any) -> np.ndarray:


### PR DESCRIPTION
As described in the title; during early stopping, reverts to the model that got the best validation score.

Implemented for both the neural network and the regression