### PR TITLE
Allow models to define prediction months

### DIFF
--- a/src/models/base.py
+++ b/src/models/base.py
@@ -16,6 +16,8 @@ class ModelBase:
     batch_size: int 1
         The number of files to load at once. These will be chunked and shuffled, so
         a higher value will lead to better shuffling (but will require more memory)
+    pred_months: Optional[List[int]] = None
+        The months the model should predict. If None, all months are predicted
     include_pred_month: bool = True
         Whether to include the prediction month to the model's training data
     """
@@ -24,11 +26,14 @@ class ModelBase:
 
     def __init__(self, data_folder: Path = Path('data'),
                  batch_size: int = 1,
+                 pred_months: Optional[List[int]] = None,
                  include_pred_month: bool = True) -> None:
 
         self.batch_size = batch_size
         self.include_pred_month = include_pred_month
         self.data_path = data_folder
+        self.pred_months = pred_months
+
         self.models_dir = data_folder / 'models'
         if not self.models_dir.exists():
             self.models_dir.mkdir()

--- a/src/models/linear_network.py
+++ b/src/models/linear_network.py
@@ -24,8 +24,9 @@ class LinearNetwork(ModelBase):
                  dropout: float = 0.25,
                  data_folder: Path = Path('data'),
                  batch_size: int = 1,
+                 pred_months: Optional[List[int]] = None,
                  include_pred_month: bool = True) -> None:
-        super().__init__(data_folder, batch_size, include_pred_month)
+        super().__init__(data_folder, batch_size, pred_months, include_pred_month)
 
         if type(layer_sizes) is int:
             layer_sizes = cast(List[int], [layer_sizes])

--- a/src/models/linear_network.py
+++ b/src/models/linear_network.py
@@ -78,24 +78,25 @@ class LinearNetwork(ModelBase):
 
         if early_stopping is not None:
             len_mask = len(DataLoader._load_datasets(self.data_path, mode='train',
-                                                     shuffle_data=False))
+                                                     shuffle_data=False,
+                                                     pred_months=self.pred_months))
             train_mask, val_mask = train_val_mask(len_mask, 0.3)
 
             train_dataloader = DataLoader(data_path=self.data_path,
                                           batch_file_size=self.batch_size,
                                           shuffle_data=True, mode='train', mask=train_mask,
-                                          to_tensor=True)
+                                          pred_months=self.pred_months, to_tensor=True)
             val_dataloader = DataLoader(data_path=self.data_path,
                                         batch_file_size=self.batch_size,
                                         shuffle_data=False, mode='train', mask=val_mask,
-                                        to_tensor=True)
+                                        pred_months=self.pred_months, to_tensor=True)
             batches_without_improvement = 0
             best_val_score = np.inf
         else:
             train_dataloader = DataLoader(data_path=self.data_path,
                                           batch_file_size=self.batch_size,
                                           shuffle_data=True, mode='train',
-                                          to_tensor=True)
+                                          pred_months=self.pred_months, to_tensor=True)
 
         # initialize the model
         if self.input_size is None:
@@ -150,7 +151,8 @@ class LinearNetwork(ModelBase):
 
     def predict(self) -> Tuple[Dict[str, Dict[str, np.ndarray]], Dict[str, np.ndarray]]:
         test_arrays_loader = DataLoader(data_path=self.data_path, batch_file_size=self.batch_size,
-                                        shuffle_data=False, mode='test', to_tensor=True)
+                                        shuffle_data=False, mode='test',
+                                        pred_months=self.pred_months, to_tensor=True)
 
         preds_dict: Dict[str, np.ndarray] = {}
         test_arrays_dict: Dict[str, Dict[str, np.ndarray]] = {}
@@ -175,6 +177,7 @@ class LinearNetwork(ModelBase):
         train_dataloader = DataLoader(data_path=self.data_path,
                                       batch_file_size=self.batch_size,
                                       shuffle_data=True, mode='train',
+                                      pred_months=self.pred_months,
                                       to_tensor=True)
         output_tensors: List[torch.Tensor] = []
         if self.include_pred_month:

--- a/src/models/parsimonious.py
+++ b/src/models/parsimonious.py
@@ -24,7 +24,8 @@ class Persistence(ModelBase):
     def predict(self) -> Tuple[Dict[str, Dict[str, np.ndarray]], Dict[str, np.ndarray]]:
 
         test_arrays_loader = DataLoader(data_path=self.data_path, batch_file_size=self.batch_size,
-                                        shuffle_data=False, mode='test', normalize=False)
+                                        shuffle_data=False, mode='test', normalize=False,
+                                        pred_months=self.pred_months)
 
         preds_dict: Dict[str, np.ndarray] = {}
         test_arrays_dict: Dict[str, Dict[str, np.ndarray]] = {}

--- a/src/models/regression.py
+++ b/src/models/regression.py
@@ -36,15 +36,18 @@ class LinearRegression(ModelBase):
 
             train_dataloader = DataLoader(data_path=self.data_path,
                                           batch_file_size=self.batch_size,
+                                          pred_months=self.pred_months,
                                           shuffle_data=True, mode='train', mask=train_mask)
             val_dataloader = DataLoader(data_path=self.data_path,
                                         batch_file_size=self.batch_size,
+                                        pred_months=self.pred_months,
                                         shuffle_data=False, mode='train', mask=val_mask)
             batches_without_improvement = 0
             best_val_score = np.inf
         else:
             train_dataloader = DataLoader(data_path=self.data_path,
                                           batch_file_size=self.batch_size,
+                                          pred_months=self.pred_months,
                                           shuffle_data=True, mode='train')
         self.model: linear_model.SGDRegressor = linear_model.SGDRegressor()
 
@@ -134,7 +137,8 @@ class LinearRegression(ModelBase):
     def predict(self) -> Tuple[Dict[str, Dict[str, np.ndarray]], Dict[str, np.ndarray]]:
 
         test_arrays_loader = DataLoader(data_path=self.data_path, batch_file_size=self.batch_size,
-                                        shuffle_data=False, mode='test')
+                                        shuffle_data=False, pred_months=self.pred_months,
+                                        mode='test')
 
         preds_dict: Dict[str, np.ndarray] = {}
         test_arrays_dict: Dict[str, Dict[str, np.ndarray]] = {}
@@ -167,6 +171,7 @@ class LinearRegression(ModelBase):
         print('Calculating the mean of the training data')
         train_dataloader = DataLoader(data_path=self.data_path,
                                       batch_file_size=1,
+                                      pred_months=self.pred_months,
                                       shuffle_data=False, mode='train')
 
         means, sizes = [], []

--- a/src/models/regression.py
+++ b/src/models/regression.py
@@ -5,7 +5,7 @@ from sklearn.metrics import mean_squared_error
 
 import shap
 
-from typing import cast, Any, Dict, Tuple, Optional, Union
+from typing import cast, Any, Dict, List, Tuple, Optional, Union
 
 from .base import ModelBase
 from .utils import chunk_array
@@ -18,8 +18,9 @@ class LinearRegression(ModelBase):
 
     def __init__(self, data_folder: Path = Path('data'),
                  batch_size: int = 1,
+                 pred_months: Optional[List[int]] = None,
                  include_pred_month: bool = True) -> None:
-        super().__init__(data_folder, batch_size, include_pred_month)
+        super().__init__(data_folder, batch_size, pred_months, include_pred_month)
 
         self.explainer: Optional[shap.LinearExplainer] = None
 

--- a/tests/models/test_data.py
+++ b/tests/models/test_data.py
@@ -27,6 +27,25 @@ class TestBaseIter:
             f'Got the same file in both train and val set!'
         assert len(train_paths) + len(val_paths) == 5, f'Not all files loaded!'
 
+    def test_pred_months(self, tmp_path):
+        for i in range(1, 13):
+            (tmp_path / f'features/train/2018_{i}').mkdir(parents=True)
+            (tmp_path / f'features/train/2018_{i}/x.nc').touch()
+            (tmp_path / f'features/train/2018_{i}/y.nc').touch()
+
+        pred_months = [4, 5, 6]
+
+        train_paths = DataLoader._load_datasets(tmp_path, mode='train',
+                                                shuffle_data=True, pred_months=pred_months)
+
+        assert len(train_paths) == len(pred_months), \
+            f'Got {len(train_paths)} filepaths back, expected {len(pred_months)}'
+
+        for return_file in train_paths:
+            subfolder = return_file.parts[-1]
+            month = int(str(subfolder)[5:])
+            assert month in pred_months, f'{month} not in {pred_months}, got {return_file}'
+
     @pytest.mark.parametrize('normalize,to_tensor', [(True, True), (True, False),
                                                      (False, True), (False, False)])
     def test_ds_to_np(self, tmp_path, normalize, to_tensor):

--- a/tests/models/test_regression.py
+++ b/tests/models/test_regression.py
@@ -82,7 +82,7 @@ class TestLinearRegression:
                         raise StopIteration()
             return MockIterator()
 
-        def do_nothing(self, data_path, batch_file_size, shuffle_data, mode):
+        def do_nothing(self, data_path, batch_file_size, shuffle_data, mode, pred_months):
             pass
 
         monkeypatch.setattr(DataLoader, '__iter__', mockiter)


### PR DESCRIPTION
Our models are currently under performing relative to the [vegetation health](https://github.com/tommylees112/vegetation_health) experiments we have done before.

One difference is that in those experiments, we predicted a single month whereas now we are predicting over the whole year.

This PR allows prediction months to be selected (or not) so that a comparison can be run