### PR TITLE
[minor] Properly label losses when training neural networks

### DIFF
--- a/tests/models/neural_networks/test_linear_network.py
+++ b/tests/models/neural_networks/test_linear_network.py
@@ -112,7 +112,7 @@ class TestLinearNetwork:
             f"Got: {n_input_features}"
 
         captured = capsys.readouterr()
-        expected_stdout = 'Epoch 1, train RMSE: 0.'
+        expected_stdout = 'Epoch 1, train smooth L1: 0.'
         assert expected_stdout in captured.out
 
         assert type(model.model) == LinearModel, \

--- a/tests/models/neural_networks/test_rnn.py
+++ b/tests/models/neural_networks/test_rnn.py
@@ -78,7 +78,7 @@ class TestRecurrentNetwork:
         model.train()
 
         captured = capsys.readouterr()
-        expected_stdout = 'Epoch 1, train RMSE: 0.'
+        expected_stdout = 'Epoch 1, train smooth L1: 0.'
         assert expected_stdout in captured.out
 
         assert type(model.model) == RNN, \


### PR DESCRIPTION
Currently, the model is trained using smooth l1 loss, and the evaluated using RMSE; this makes it hard to gauge the performance of the model on the test set vs training set.

This PR ensures the training RMSE is also calculated and printed.