### PR TITLE
Allow models to see latitude and longitude of target pixels

### DIFF
--- a/src/models/base.py
+++ b/src/models/base.py
@@ -20,6 +20,9 @@ class ModelBase:
         The months the model should predict. If None, all months are predicted
     include_pred_month: bool = True
         Whether to include the prediction month to the model's training data
+    include_latlons: bool = True
+        Whether to include prediction pixel latitudes and longitudes in the model's
+        training data
     """
 
     model_name: str  # to be added by the model classes
@@ -29,10 +32,12 @@ class ModelBase:
                  experiment: str = 'one_month_forecast',
                  pred_months: Optional[List[int]] = None,
                  include_pred_month: bool = True,
+                 include_latlons: bool = True,
                  surrounding_pixels: Optional[int] = None) -> None:
 
         self.batch_size = batch_size
         self.include_pred_month = include_pred_month
+        self.include_latlons = include_latlons
         self.data_path = data_folder
         self.experiment = experiment
         self.pred_months = pred_months

--- a/src/models/data.py
+++ b/src/models/data.py
@@ -16,6 +16,9 @@ class TrainData:
     historical: Union[np.ndarray, torch.Tensor]
     current: Union[np.ndarray, torch.Tensor, None]
     pred_months: Union[np.ndarray, torch.Tensor]
+    # latlons are repeated here so they can be tensor-ized and
+    # normalized
+    latlons: Union[np.ndarray, torch.Tensor]
 
 
 @dataclass
@@ -194,16 +197,18 @@ class _BaseIter:
     def ds_folder_to_np(self,
                         folder: Path,
                         clear_nans: bool = True,
-                        return_latlons: bool = False,
                         to_tensor: bool = False
                         ) -> ModelArrays:
 
         x, y = xr.open_dataset(folder / 'x.nc'), xr.open_dataset(folder / 'y.nc')
         assert len(list(y.data_vars)) == 1, f'Expect only 1 target variable! ' \
             f'Got {len(list(y.data_vars))}'
+
         if self.surrounding_pixels is not None:
             x = self._add_surrounding(x, self.surrounding_pixels)
+
         x_np, y_np = x.to_array().values, y.to_array().values
+
         if (self.normalizing_dict is not None) and (self.normalizing_array is None):
             self.calculate_normalizing_array(list(x.data_vars))
 
@@ -219,12 +224,19 @@ class _BaseIter:
         ).month
         x_months = np.array([target_month] * x_np.shape[0])
 
+        # then, latlons
+        lons, lats = np.meshgrid(x.lon.values, x.lat.values)
+        flat_lats, flat_lons = lats.reshape(-1, 1), lons.reshape(-1, 1)
+        latlons = np.concatenate((flat_lats, flat_lons), axis=-1)
+        train_latlons = np.concatenate((flat_lats, flat_lons), axis=-1)
+
         # then, y
         y_np = y_np.reshape(y_np.shape[0], y_np.shape[1], y_np.shape[2] * y_np.shape[3])
         y_np = np.moveaxis(y_np, -1, 0).reshape(-1, 1)
 
         if self.normalizing_array is not None:
             x_np = (x_np - self.normalizing_array['mean']) / (self.normalizing_array['std'])
+            train_latlons = train_latlons / [90, 180]
 
         if self.experiment == 'nowcast':
             # if nowcast then we have a TrainData.current
@@ -236,14 +248,16 @@ class _BaseIter:
             train_data = TrainData(
                 current=current,
                 historical=historical,
-                pred_months=x_months
+                pred_months=x_months,
+                latlons=train_latlons
             )
 
         else:
             train_data = TrainData(
                 current=None,
                 historical=x_np,
-                pred_months=x_months
+                pred_months=x_months,
+                latlons=train_latlons
             )
 
         assert y_np.shape[0] == x_np.shape[0], f'x and y data have a different ' \
@@ -272,34 +286,24 @@ class _BaseIter:
                 )[0]
                 train_data.current = train_data.current[notnan_indices]  # type: ignore
 
-            train_data.historical, y_np = (
-                train_data.historical[notnan_indices], y_np[notnan_indices]
-            )
+            train_data.historical = train_data.historical[notnan_indices]
             train_data.pred_months = train_data.pred_months[notnan_indices]  # type: ignore
+            train_data.latlons = train_data.latlons[notnan_indices]
+            y_np = y_np[notnan_indices]
+
+            latlons = latlons[notnan_indices]
 
         if to_tensor:
-            train_data.historical, y_np = (
-                torch.from_numpy(train_data.historical).float(),
-                torch.from_numpy(y_np).float()
-            )
+            train_data.historical = torch.from_numpy(train_data.historical).float()
             train_data.pred_months = torch.from_numpy(train_data.pred_months).float()
+            train_data.latlons = torch.from_numpy(train_data.latlons).float()
+            y_np = torch.from_numpy(y_np).float()
 
             if self.experiment == 'nowcast':
                 train_data.current = torch.from_numpy(train_data.current).float()
 
-        if return_latlons:
-            lons, lats = np.meshgrid(x.lon.values, x.lat.values)
-            flat_lats, flat_lons = lats.reshape(-1, 1), lons.reshape(-1, 1)
-            latlons = np.concatenate((flat_lats, flat_lons), axis=-1)
-
-            if clear_nans:
-                latlons = latlons[notnan_indices]
-
-            return ModelArrays(x=train_data, y=y_np, x_vars=list(x.data_vars),
-                               y_var=list(y.data_vars)[0], latlons=latlons)
-
         return ModelArrays(x=train_data, y=y_np, x_vars=list(x.data_vars),
-                           y_var=list(y.data_vars)[0])
+                           y_var=list(y.data_vars)[0], latlons=latlons)
 
     @staticmethod
     def _add_surrounding(x: xr.Dataset, surrounding_pixels: int) -> xr.Dataset:
@@ -348,14 +352,14 @@ class _TrainIter(_BaseIter):
                                 Union[np.ndarray, torch.Tensor]]:
 
         if self.idx < self.max_idx:
-            out_x, out_x_add, out_y, out_x_curr = [], [], [], []
+            out_x, out_x_add, out_x_curr, out_x_latlon, out_y = [], [], [], [], []
 
             cur_max_idx = min(self.idx + self.batch_file_size, self.max_idx)
             while self.idx < cur_max_idx:
                 subfolder = self.data_files[self.idx]
                 arrays = self.ds_folder_to_np(
                     subfolder, clear_nans=self.clear_nans,
-                    return_latlons=False, to_tensor=False
+                    to_tensor=False
                 )
                 if arrays.x.historical.shape[0] == 0:
                     print(f'{subfolder} returns no values. Skipping')
@@ -370,30 +374,30 @@ class _TrainIter(_BaseIter):
                 if arrays.x.current is not None:
                     out_x_curr.append(arrays.x.current)
                 out_x_add.append(arrays.x.pred_months)
+                out_x_latlon.append(arrays.x.latlons)
                 out_y.append(arrays.y)
                 self.idx += 1
 
             final_x = np.concatenate(out_x, axis=0)
             final_x_curr = np.concatenate(out_x_curr, axis=0) if out_x_curr != [] else None
             final_x_add = np.concatenate(out_x_add, axis=0)
+            final_x_latlon = np.concatenate(out_x_latlon, axis=0)
             final_y = np.concatenate(out_y, axis=0)
 
             if self.to_tensor:
-                # x matrix
                 final_x = torch.from_numpy(final_x).float()
-                # pred_months data
                 final_x_add = torch.from_numpy(final_x_add).float()
-                # current timestep data
+                final_x_latlon = torch.from_numpy(final_x_latlon).float()
                 final_x_curr = torch.from_numpy(
                     final_x_curr
                 ).float() if final_x_curr is not None else None
-                # y (target) data
+
                 final_y = torch.from_numpy(final_y).float()
 
             if final_x.shape[0] == 0:
                 raise StopIteration()
 
-            return (final_x, final_x_add, final_x_curr), final_y
+            return (final_x, final_x_add, final_x_latlon, final_x_curr), final_y
 
         else:  # final_x_curr >= self.max_idx
             raise StopIteration()
@@ -410,7 +414,7 @@ class _TestIter(_BaseIter):
             while self.idx < cur_max_idx:
                 subfolder = self.data_files[self.idx]
                 arrays = self.ds_folder_to_np(subfolder, clear_nans=self.clear_nans,
-                                              return_latlons=True, to_tensor=self.to_tensor)
+                                              to_tensor=self.to_tensor)
                 if arrays.x.historical.shape[0] == 0:
                     print(f'{subfolder} returns no values. Skipping')
                     # remove the empty element from the list

--- a/src/models/data.py
+++ b/src/models/data.py
@@ -367,6 +367,7 @@ class _TrainIter(_BaseIter):
                     # remove the empty element from the list
                     self.data_files.pop(self.idx)
                     self.max_idx -= 1
+                    self.idx -= 1  # we're going to add one later
 
                     cur_max_idx = min(cur_max_idx + 1, self.max_idx)
 

--- a/src/models/regression.py
+++ b/src/models/regression.py
@@ -5,11 +5,11 @@ from sklearn.metrics import mean_squared_error
 
 import shap
 
-from typing import cast, Any, Dict, List, Tuple, Optional, Union
+from typing import cast, Dict, List, Tuple, Optional
 
 from .base import ModelBase
 from .utils import chunk_array
-from .data import DataLoader, train_val_mask
+from .data import DataLoader, train_val_mask, TrainData
 
 
 class LinearRegression(ModelBase):
@@ -21,9 +21,10 @@ class LinearRegression(ModelBase):
                  batch_size: int = 1,
                  pred_months: Optional[List[int]] = None,
                  include_pred_month: bool = True,
+                 include_latlons: bool = True,
                  surrounding_pixels: Optional[int] = None) -> None:
         super().__init__(data_folder, batch_size, experiment, pred_months,
-                         include_pred_month, surrounding_pixels)
+                         include_pred_month, include_latlons, surrounding_pixels)
 
         self.explainer: Optional[shap.LinearExplainer] = None
 
@@ -45,6 +46,7 @@ class LinearRegression(ModelBase):
                                           shuffle_data=True, mode='train',
                                           pred_months=self.pred_months,
                                           mask=train_mask,
+
                                           surrounding_pixels=self.surrounding_pixels)
             val_dataloader = DataLoader(data_path=self.data_path,
                                         batch_file_size=self.batch_size,
@@ -85,10 +87,10 @@ class LinearRegression(ModelBase):
                         x_in = np.concatenate(
                             (x_in, pred_months_onehot), axis=-1
                         )
-
-                    # target timestep (non-target variables)
+                    if self.include_latlons:
+                        x_in = np.concatenate((x_in, batch_x[2]), axis=-1)
                     if self.experiment == 'nowcast':
-                        current_time_data = batch_x[2]
+                        current_time_data = batch_x[3]
                         x_in = np.concatenate(
                             (x_in, current_time_data), axis=-1
                         )
@@ -114,9 +116,10 @@ class LinearRegression(ModelBase):
                         x_in = np.concatenate(
                             (x_in, pred_months_onehot), axis=-1
                         )
-
+                    if self.include_latlons:
+                        x_in = np.concatenate((x_in, x[2]), axis=-1)
                     if self.experiment == 'nowcast':
-                        current_time_data = x[2]
+                        current_time_data = x[3]
                         x_in = np.concatenate(
                             (x_in, current_time_data), axis=-1
                         )
@@ -142,8 +145,7 @@ class LinearRegression(ModelBase):
                         self.model.intercept_ = best_intercept
                         return None
 
-    def explain(self, x: Any) -> Union[np.ndarray,
-                                       Tuple[np.ndarray, np.ndarray]]:
+    def explain(self, data: TrainData) -> Tuple[np.ndarray, ...]:
 
         assert self.model is not None, 'Model must be trained!'
 
@@ -152,22 +154,27 @@ class LinearRegression(ModelBase):
             self.explainer: shap.LinearExplainer = shap.LinearExplainer(
                 self.model, (mean, None), feature_dependence='independent')
 
-        if self.include_pred_month:
-            assert type(x) in (tuple, list), 'Input x must be a tuple or list'\
-                f'Got {type(x)}'
-            x, pred_months = x
-            pred_months = np.eye(14)[pred_months][:, 1:-1]
+        x = data.historical
         batch, timesteps, dims = x.shape[0], x.shape[1], x.shape[2]
         reshaped_x = x.reshape(batch, timesteps * dims)
-        if self.include_pred_month:
-            reshaped_x = np.concatenate((reshaped_x, pred_months), axis=-1)
-        explanations = self.explainer.shap_values(reshaped_x)
 
-        if not self.include_pred_month:
-            return explanations.reshape(batch, timesteps, dims)
+        if self.include_pred_month:
+            pred_months = data.pred_months
+            pred_months = np.eye(14)[pred_months][:, 1:-1]
+            reshaped_x = np.concatenate((reshaped_x, pred_months), axis=-1)
+        if self.include_latlons:
+            latlons = data.latlons
+            reshaped_x = np.concatenate((reshaped_x, latlons), axis=-1)
+        if self.experiment == 'nowcast':
+            current = data.current
+            reshaped_x = np.concatenate((reshaped_x, current), axis=-1)
+
+        explanations = self.explainer.shap_values(reshaped_x)
 
         historical = explanations[:, :timesteps * dims]
         additional = explanations[:, timesteps * dims:]
+
+        # TODO: properly split the additional arrays
 
         return historical.reshape(batch, timesteps, dims), additional
 
@@ -200,7 +207,8 @@ class LinearRegression(ModelBase):
                     # for us its + 2, since 0 is not a class either
                     pred_months_onehot = np.eye(14)[pred_months][:, 1:-1]
                     x = np.concatenate((x, pred_months_onehot), axis=-1)
-
+                if self.include_latlons:
+                    x = np.concatenate((x, val.x.latlons), axis=-1)
                 if self.experiment == 'nowcast':
                     # target_month data for non-target variables
                     current_data = val.x.current

--- a/tests/models/neural_networks/test_rnn.py
+++ b/tests/models/neural_networks/test_rnn.py
@@ -20,16 +20,20 @@ class TestRecurrentNetwork:
         rnn_dropout = 0.25
         dense_dropout = 0.25
         include_pred_month = True
+        include_latlons = True
 
         def mocktrain(self):
             self.model = RNN(features_per_month, dense_features, hidden_size,
                              rnn_dropout, dense_dropout,
-                             include_pred_month, experiment='one_month_forecast')
+                             include_pred_month, include_latlons,
+                             experiment='one_month_forecast')
             self.features_per_month = features_per_month
 
         monkeypatch.setattr(RecurrentNetwork, 'train', mocktrain)
 
         model = RecurrentNetwork(hidden_size=hidden_size, dense_features=dense_features,
+                                 include_pred_month=include_pred_month,
+                                 include_latlons=include_latlons,
                                  rnn_dropout=rnn_dropout, data_folder=tmp_path)
         model.train()
         model.save_model()
@@ -48,6 +52,7 @@ class TestRecurrentNetwork:
         assert model_dict['dense_dropout'] == dense_dropout
         assert model_dict['dense_features'] == dense_features
         assert model_dict['include_pred_month'] == include_pred_month
+        assert model_dict['include_latlons'] == include_latlons
         assert model_dict['experiment'] == 'one_month_forecast'
 
     @pytest.mark.parametrize('use_pred_months', [True, False])

--- a/tests/models/test_data.py
+++ b/tests/models/test_data.py
@@ -103,8 +103,7 @@ class TestBaseIter:
 
         base_iterator = _BaseIter(MockLoader())
 
-        arrays = base_iterator.ds_folder_to_np(data_dir, return_latlons=True,
-                                               to_tensor=to_tensor)
+        arrays = base_iterator.ds_folder_to_np(data_dir, to_tensor=to_tensor)
 
         x_train_data, y_np, latlons = (
             arrays.x, arrays.y, arrays.latlons
@@ -128,6 +127,9 @@ class TestBaseIter:
 
         expected_latlons = 25 if surrounding_pixels is None else 9
         assert latlons.shape == (expected_latlons, 2), "The shape of "\
+            "latlons should not change"\
+            f"Got: {latlons.shape}. Expecting: (25, 2)"
+        assert x_train_data.latlons.shape == (expected_latlons, 2), "The shape of "\
             "latlons should not change"\
             f"Got: {latlons.shape}. Expecting: (25, 2)"
 

--- a/tests/models/test_regression.py
+++ b/tests/models/test_regression.py
@@ -86,8 +86,8 @@ class TestLinearRegression:
             f'Model attribute not a linear regression!'
 
         if (experiment != 'nowcast') and (use_pred_months):
-            assert model.model.coef_.size == 120, "Expecting 120 coefficients" \
-                "(3 historical vars * 36 months) + 12 pred_months one_hot encoded"
+            assert model.model.coef_.size == 122, "Expecting 120 coefficients" \
+                "(3 historical vars * 36 months) + 12 pred_months one_hot encoded + 2 latlons"
 
         # Test Predictions / Evaluations
         test_arrays_dict, preds_dict = model.predict()
@@ -97,11 +97,11 @@ class TestLinearRegression:
             ), "Expected length of test arrays to be the same as the predictions"
 
             if use_pred_months:
-                assert model.model.coef_.size == 119, "Expect to have 119 coefficients" \
-                    " (35 tstep x 3 historical) + 12 pred_months_one_hot + 2 current"
+                assert model.model.coef_.size == 121, "Expect to have 119 coefficients" \
+                    " (35 tstep x 3 historical) + 12 pred_months_one_hot + 2 current + 2 latlons"
             else:
-                assert model.model.coef_.size == 107, "Expect to have 107 coefficients" \
-                    " (35 tstep x 3 historical) + 2 current"
+                assert model.model.coef_.size == 109, "Expect to have 107 coefficients" \
+                    " (35 tstep x 3 historical) + 2 current + 2 latlons"
 
     def test_big_mean(self, tmp_path, monkeypatch):
 


### PR DESCRIPTION
As described - this passes the latitude and longitudes to the models.

They are normalized by their max (i.e. `norm_lat = lat / 90`). This means that for Kenya, the maximum is small, but this will allow us to easily adapt to any use case.