### PR TITLE
Calculate normalization values uniformly across time

### DIFF
--- a/tests/engineer/test_nowcast.py
+++ b/tests/engineer/test_nowcast.py
@@ -93,17 +93,9 @@ class TestNowcastEngineer:
         for key, val in norm_dict.items():
             assert key in {'a', 'b'}, f'Unexpected key!'
             # TODO: fix how to test for the final (12th) value
-            if key == 'a':
-                assert (norm_dict[key]['mean'] == 1)[:-1].all(), \
-                    f'Mean incorrectly calculated!'
-                assert (norm_dict[key]['mean'][-1] == -9999), \
-                    f'Mean incorrectly calculated!'
-            else:
-                assert (norm_dict[key]['mean'] == 1).all(), \
-                    f'Mean incorrectly calculated!'
-            assert len(norm_dict[key]['mean']) == 12,\
-                f'Mean should be of length 12'
-            assert (norm_dict[key]['std'] == 0).all(), \
+            assert norm_dict[key]['mean'] == 1, \
+                f'Mean incorrectly calculated!'
+            assert norm_dict[key]['std'] == 0, \
                 f'Std incorrectly calculated!'
 
     def test_stratify(self, tmp_path):

--- a/tests/engineer/test_one_month_forecast.py
+++ b/tests/engineer/test_one_month_forecast.py
@@ -92,9 +92,9 @@ class TestOneMonthForecastEngineer:
 
         for key, val in norm_dict.items():
             assert key in {'a', 'b'}, f'Unexpected key!'
-            assert (norm_dict[key]['mean'] == 1).all(), \
+            assert norm_dict[key]['mean'] == 1, \
                 f'Mean incorrectly calculated!'
-            assert (norm_dict[key]['std'] == 0).all(), \
+            assert norm_dict[key]['std'] == 0, \
                 f'Std incorrectly calculated!'
 
     def test_stratify(self, tmp_path):

--- a/tests/models/neural_networks/test_ealstm.py
+++ b/tests/models/neural_networks/test_ealstm.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pickle
 import pytest
 
@@ -65,9 +64,7 @@ class TestEARecurrentNetwork:
         test_features = tmp_path / 'features/one_month_forecast/train/hello'
         test_features.mkdir(parents=True)
 
-        norm_dict = {'VHI': {'mean': np.zeros(x.to_array().values.shape[:2]),
-                             'std': np.ones(x.to_array().values.shape[:2])}
-                     }
+        norm_dict = {'VHI': {'mean': 0, 'std': 1}}
         with (tmp_path / 'features/one_month_forecast/normalizing_dict.pkl').open('wb') as f:
             pickle.dump(norm_dict, f)
 
@@ -112,9 +109,7 @@ class TestEARecurrentNetwork:
         test_features = tmp_path / 'features/one_month_forecast/test/hello'
         test_features.mkdir(parents=True)
 
-        norm_dict = {'VHI': {'mean': np.zeros(x.to_array().values.shape[:2]),
-                             'std': np.ones(x.to_array().values.shape[:2])}
-                     }
+        norm_dict = {'VHI': {'mean': 0.0, 'std': 1.0}}
         with (tmp_path / 'features/one_month_forecast/normalizing_dict.pkl').open('wb') as f:
             pickle.dump(norm_dict, f)
 

--- a/tests/models/neural_networks/test_linear_network.py
+++ b/tests/models/neural_networks/test_linear_network.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pickle
 import pytest
 import xarray as xr
@@ -80,12 +79,9 @@ class TestLinearNetwork:
         x_add2, _, _ = _make_dataset(size=(5, 5), const=True, variable_name='temp')
         x = xr.merge([x, x_add1, x_add2])
 
-        norm_dict = {'VHI': {'mean': np.zeros((1, x.to_array().values.shape[1])),
-                             'std': np.ones((1, x.to_array().values.shape[1]))},
-                     'precip': {'mean': np.zeros((1, x.to_array().values.shape[1])),
-                                'std': np.ones((1, x.to_array().values.shape[1]))},
-                     'temp': {'mean': np.zeros((1, x.to_array().values.shape[1])),
-                              'std': np.ones((1, x.to_array().values.shape[1]))}}
+        norm_dict = {'VHI': {'mean': 0, 'std': 1},
+                     'precip': {'mean': 0, 'std': 1},
+                     'temp': {'mean': 0, 'std': 1}}
 
         test_features = tmp_path / f'features/{experiment}/train/hello'
         test_features.mkdir(parents=True, exist_ok=True)
@@ -194,16 +190,11 @@ class TestLinearNetwork:
             x_add2, _, _ = _make_dataset(size=(5, 5), const=True, variable_name='temp')
             x = xr.merge([x, x_add1, x_add2])
 
-            norm_dict = {'VHI': {'mean': np.zeros((1, x.to_array().values.shape[1])),
-                                 'std': np.ones((1, x.to_array().values.shape[1]))},
-                         'precip': {'mean': np.zeros((1, x.to_array().values.shape[1])),
-                                    'std': np.ones((1, x.to_array().values.shape[1]))},
-                         'temp': {'mean': np.zeros((1, x.to_array().values.shape[1])),
-                                  'std': np.ones((1, x.to_array().values.shape[1]))}}
+            norm_dict = {'VHI': {'mean': 0, 'std': 1},
+                         'precip': {'mean': 0, 'std': 1},
+                         'temp': {'mean': 0, 'std': 1}}
         else:
-            norm_dict = {'VHI': {'mean': np.zeros(x.to_array().values.shape[:2]),
-                                 'std': np.ones(x.to_array().values.shape[:2])}
-                         }
+            norm_dict = {'VHI': {'mean': 0, 'std': 1}}
 
         with (
             tmp_path / f'features/{experiment}/normalizing_dict.pkl'
@@ -247,9 +238,7 @@ class TestLinearNetwork:
         x.to_netcdf(train_features / 'x.nc')
         y.to_netcdf(train_features / 'y.nc')
 
-        norm_dict = {'VHI': {'mean': np.zeros(x.to_array().values.shape[:2]),
-                             'std': np.ones(x.to_array().values.shape[:2])}
-                     }
+        norm_dict = {'VHI': {'mean': 0, 'std': 1}}
         with (
             tmp_path / 'features/one_month_forecast/normalizing_dict.pkl'
         ).open('wb') as f:

--- a/tests/models/neural_networks/test_rnn.py
+++ b/tests/models/neural_networks/test_rnn.py
@@ -67,9 +67,7 @@ class TestRecurrentNetwork:
         test_features = tmp_path / 'features/one_month_forecast/train/hello'
         test_features.mkdir(parents=True)
 
-        norm_dict = {'VHI': {'mean': np.zeros(x.to_array().values.shape[:2]),
-                             'std': np.ones(x.to_array().values.shape[:2])}
-                     }
+        norm_dict = {'VHI': {'mean': 0, 'std': 1}}
         with (tmp_path / 'features/one_month_forecast/normalizing_dict.pkl').open('wb') as f:
             pickle.dump(norm_dict, f)
 
@@ -115,9 +113,7 @@ class TestRecurrentNetwork:
         test_features = tmp_path / 'features/one_month_forecast/test/hello'
         test_features.mkdir(parents=True)
 
-        norm_dict = {'VHI': {'mean': np.zeros(x.to_array().values.shape[:2]),
-                             'std': np.ones(x.to_array().values.shape[:2])}
-                     }
+        norm_dict = {'VHI': {'mean': 0.0, 'std': 1.0}}
         with (tmp_path / 'features/one_month_forecast/normalizing_dict.pkl').open('wb') as f:
             pickle.dump(norm_dict, f)
 

--- a/tests/models/test_data.py
+++ b/tests/models/test_data.py
@@ -85,8 +85,8 @@ class TestBaseIter:
         norm_dict = {}
         for var in x.data_vars:
             norm_dict[var] = {
-                'mean': x[var].mean(dim=['lat', 'lon'], skipna=True).values,
-                'std': x[var].std(dim=['lat', 'lon'], skipna=True).values
+                'mean': float(x[var].mean(dim=['lat', 'lon', 'time'], skipna=True).values),
+                'std': float(x[var].std(dim=['lat', 'lon', 'time'], skipna=True).values)
             }
 
         class MockLoader:

--- a/tests/models/test_regression.py
+++ b/tests/models/test_regression.py
@@ -61,12 +61,9 @@ class TestLinearRegression:
         x_add2, _, _ = _make_dataset(size=(5, 5), const=True, variable_name='temp')
         x = xr.merge([x, x_add1, x_add2])
 
-        norm_dict = {'VHI': {'mean': np.zeros((1, x.to_array().values.shape[1])),
-                             'std': np.ones((1, x.to_array().values.shape[1]))},
-                     'precip': {'mean': np.zeros((1, x.to_array().values.shape[1])),
-                                'std': np.ones((1, x.to_array().values.shape[1]))},
-                     'temp': {'mean': np.zeros((1, x.to_array().values.shape[1])),
-                              'std': np.ones((1, x.to_array().values.shape[1]))}}
+        norm_dict = {'VHI': {'mean': 0, 'std': 1},
+                     'precip': {'mean': 0, 'std': 1},
+                     'temp': {'mean': 0, 'std': 1}}
 
         static_norm_dict = {'VHI': {'mean': 0.0,
                             'std': 1.0}}


### PR DESCRIPTION
As described. We previously calculated normalization values independently for each time step - this really doesn't make much sense, since the model is trying to learn patterns of variations across time.