### PR TITLE
Add variational dropout for recurrent models

### DIFF
--- a/src/models/neural_networks/ealstm.py
+++ b/src/models/neural_networks/ealstm.py
@@ -7,6 +7,7 @@ import pickle
 from typing import Dict, List, Optional, Tuple
 
 from .base import NNBase
+from .utils import VariationalDropout
 
 
 class EARecurrentNetwork(NNBase):
@@ -245,7 +246,7 @@ class EALSTMCell(nn.Module):
 
         self.sigmoid = nn.Sigmoid()
         self.tanh = nn.Tanh()
-        self.dropout = nn.Dropout(dropout)
+        self.dropout = VariationalDropout(dropout)
 
         self.reset_parameters()
 
@@ -316,6 +317,9 @@ class EALSTMCell(nn.Module):
             # store intermediate hidden/cell state in list
             h_n.append(h_1)
             c_n.append(c_1)
+
+            if self.training & (t == 0):
+                self.dropout.update_mask(h_1.shape, h_1.is_cuda)
 
             h_x = (self.dropout(h_1), c_1)
 

--- a/src/models/neural_networks/utils.py
+++ b/src/models/neural_networks/utils.py
@@ -1,0 +1,25 @@
+import torch
+from torch import nn
+
+
+class VariationalDropout(nn.Module):
+    """
+    This ensures the same dropout is applied to each timestep,
+    as described in https://arxiv.org/pdf/1512.05287.pdf
+    """
+    def __init__(self, p):
+        super().__init__()
+
+        self.p = p
+        self.mask = None
+
+    def update_mask(self, x_shape, is_cuda):
+        mask = torch.bernoulli(torch.ones(x_shape) * (1 - self.p)) / (1 - self.p)
+        if is_cuda: mask = mask.cuda()
+        self.mask = mask
+
+    def forward(self, x):
+        if not self.training:
+            return x
+
+        return self.mask * x


### PR DESCRIPTION
As in https://arxiv.org/pdf/1512.05287.pdf

The motivation is that dropout between hidden timesteps makes it hard for the models to learn patterns across time, since activations are randomly masked.

The solution is to apply the same dropout mask to each timestep in a minibatch.