### PR TITLE
Engineer/train years

### DIFF
--- a/scripts/experiments/02_different_training_periods.py
+++ b/scripts/experiments/02_different_training_periods.py
@@ -1,5 +1,3 @@
-from scripts.utils import get_data_path
-from _base_models import parsimonious, regression, linear_nn, rnn, earnn
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -13,6 +11,8 @@ from src.engineer import Engineer
 from src.analysis import read_train_data, read_test_data
 from src.analysis import all_explanations_for_file
 from src.engineer import Engineer
+from scripts.utils import get_data_path
+from _base_models import parsimonious, regression, linear_nn, rnn, earnn
 
 
 def sort_by_median_target_variable(

--- a/scripts/experiments/02_different_training_periods.py
+++ b/scripts/experiments/02_different_training_periods.py
@@ -1,6 +1,3 @@
-from src.engineer import Engineer
-from src.analysis import read_train_data, read_test_data
-from src.analysis import all_explanations_for_file
 from scripts.utils import get_data_path
 from _base_models import parsimonious, regression, linear_nn, rnn, earnn
 import numpy as np
@@ -11,6 +8,10 @@ from typing import List, Union, Tuple, Dict
 import sys
 
 sys.path.append("../..")
+
+from src.engineer import Engineer
+from src.analysis import read_train_data, read_test_data
+from src.analysis import all_explanations_for_file
 
 
 def sort_by_median_target_variable(
@@ -268,24 +269,26 @@ def run_training_period_experiments():
             test_length=3,
         )
 
-        debug = False
+        debug = True
         if debug:
             print(
-                experiment.train_length,
-                experiment.test_hilo,
-                experiment.train_hilo,
-                "train_years:\n",
-                train_years,
-                "\n",
-                "test_years:\n",
-                test_years,
-                "\n",
+                '\n' + '-' * 10 + '\n',
+                "train_length: " + str(experiment.train_length),
+                "test_hilo: " + experiment.test_hilo,
+                "train_hilo: " + experiment.train_hilo,
+                "train_years:\n", train_years, "\n",
+                "test_years:\n", test_years,
+                '\n' + '-' * 10 + '\n',
             )
 
+        # have to recreate each engineer for the experiment
+        # TODO: definite inefficiency
         engineer = Engineer(
             get_data_path(),
             experiment="one_month_forecast",
             process_static=True,
+        )
+        engineer.engineer(
             test_year=test_years,
             train_years=train_years,
         )

--- a/scripts/experiments/02_different_training_periods.py
+++ b/scripts/experiments/02_different_training_periods.py
@@ -12,6 +12,7 @@ sys.path.append("../..")
 from src.engineer import Engineer
 from src.analysis import read_train_data, read_test_data
 from src.analysis import all_explanations_for_file
+from src.engineer import Engineer
 
 
 def sort_by_median_target_variable(
@@ -287,6 +288,7 @@ def run_training_period_experiments():
             get_data_path(),
             experiment="one_month_forecast",
             process_static=True,
+            different_training_periods = True
         )
         engineer.engineer(
             test_year=test_years,

--- a/scripts/experiments/02_different_training_periods.py
+++ b/scripts/experiments/02_different_training_periods.py
@@ -246,14 +246,18 @@ def run_training_period_experiments(pred_months: int = 3):
     expected_length = pred_months
 
     # Read the target data
+    print('** Reading the target data **')
     data_dir = get_data_path()
     target_data = xr.open_dataset(
         data_dir / "interim" / "VCI_preprocessed" / "data_kenya.nc"
     )
     # sort by the annual median (across pixels/time)
+    print('** Sorting the target data **')
     sorted_years, _ = sort_by_median_target_variable(target_data)
+    print(f'** sorted_years: {sorted_years} **')
 
     # create all experiments
+    print('** Creating all experiments **')
     hilos = ["high", "med", "low"]
     train_lengths = [5, 10, 20]
     experiments = [
@@ -265,6 +269,7 @@ def run_training_period_experiments(pred_months: int = 3):
         )
     ]
 
+    print('** Running all experiments **')
     for experiment in experiments:
         test_years, train_years = get_experiment_years(
             sorted_years,

--- a/scripts/experiments/02_different_training_periods.py
+++ b/scripts/experiments/02_different_training_periods.py
@@ -242,14 +242,18 @@ class Experiment:
         assert test_hilo in ["high", "med", "low"]
 
 
-def run_training_period_experiments():
+def run_training_period_experiments(pred_months: int = 3):
+    expected_length = pred_months
+
+    # Read the target data
     data_dir = get_data_path()
     target_data = xr.open_dataset(
         data_dir / "interim" / "VCI_preprocessed" / "data_kenya.nc"
     )
+    # sort by the annual median (across pixels/time)
     sorted_years, _ = sort_by_median_target_variable(target_data)
 
-    # get all experiments
+    # create all experiments
     hilos = ["high", "med", "low"]
     train_lengths = [5, 10, 20]
     experiments = [
@@ -283,7 +287,7 @@ def run_training_period_experiments():
             )
 
         # have to recreate each engineer for the experiment
-        # TODO: definite inefficiency
+        # TODO: definite inefficiency should this be in DataLoader?
         engineer = Engineer(
             get_data_path(),
             experiment="one_month_forecast",
@@ -293,10 +297,14 @@ def run_training_period_experiments():
         engineer.engineer(
             test_year=test_years,
             train_years=train_years,
+            pred_months=pred_months,
+            expected_length=expected_length,
         )
 
-    pass
+        break
+
 
 
 if __name__ == "__main__":
-    run_training_period_experiments()
+    pred_months = 3
+    run_training_period_experiments(pred_months=3)

--- a/src/engineer/__init__.py
+++ b/src/engineer/__init__.py
@@ -4,6 +4,7 @@ from typing import Union, List, Optional
 
 from .nowcast import _NowcastEngineer
 from .one_month_forecast import _OneMonthForecastEngineer
+from .different_training_periods import _DifferentTrainingPeriodsEngineer
 from .base import _EngineerBase
 
 
@@ -25,6 +26,7 @@ class Engineer:
         data_folder: Path = Path("data_path"),
         process_static: bool = True,
         experiment: str = "one_month_forecast",
+        different_training_periods: bool = False,
     ) -> None:
 
         assert experiment in {
@@ -34,7 +36,10 @@ class Engineer:
 
         engineer: _EngineerBase
         if experiment == "one_month_forecast":
-            engineer = _OneMonthForecastEngineer(data_folder, process_static)
+            if different_training_periods:
+                engineer = _DifferentTrainingPeriodsEngineer(data_folder, process_static)
+            else:
+                engineer = _OneMonthForecastEngineer(data_folder, process_static)
         elif experiment == "nowcast":
             engineer = _NowcastEngineer(data_folder, process_static)
         self.engineer_class = engineer

--- a/src/engineer/base.py
+++ b/src/engineer/base.py
@@ -43,15 +43,9 @@ class _EngineerBase:
         target_variable: str = "VHI",
         pred_months: int = 12,
         expected_length: Optional[int] = 12,
-        train_years: Optional[List[int]] = None,
     ) -> None:
 
-        self._process_dynamic(
-            test_year,
-            target_variable,
-            pred_months,
-            expected_length,
-            train_years)
+        self._process_dynamic(test_year, target_variable, pred_months, expected_length)
         if self.process_static:
             self._process_static()
 
@@ -90,12 +84,12 @@ class _EngineerBase:
         with savepath.open("wb") as f:
             pickle.dump(normalization_values, f)
 
-    def _process_dynamic(self,
+    def _process_dynamic(
+        self,
         test_year: Union[int, List[int]],
         target_variable: str = "VHI",
         pred_months: int = 12,
         expected_length: Optional[int] = 12,
-        train_years: Optional[List[int]] = None
     ) -> None:
         if expected_length is None:
             warnings.warn(
@@ -118,15 +112,9 @@ class _EngineerBase:
             pred_months=pred_months,
             expected_length=expected_length,
         )
-        assert train_ds.time.shape[0] > 0, 'Expect the train_ds to have' \
-            f'`time` dimension. \n{train_ds}'
-
-        if train_years is not None:
-            # select only the TRAINING years in train_years
-            ds_years = train_ds['time.year'].values
-            bool_train_years = [y in train_years for y in ds_years]
-            train_ds.sel(time=bool_train_years)
-            assert False
+        assert train_ds.time.shape[0] > 0, (
+            "Expect the train_ds to have" f"`time` dimension. \n{train_ds}"
+        )
 
         normalization_values = self._calculate_normalization_values(train_ds)
 
@@ -313,7 +301,7 @@ class _EngineerBase:
 
     @staticmethod
     def _make_fill_value_dataset(
-        ds: Union[xr.Dataset, xr.DataArray], fill_value: Union[int, float] = -9999.0,
+        ds: Union[xr.Dataset, xr.DataArray], fill_value: Union[int, float] = -9999.0
     ) -> Union[xr.Dataset, xr.DataArray]:
         nan_ds = xr.full_like(ds, fill_value)
         return nan_ds

--- a/src/engineer/different_training_periods.py
+++ b/src/engineer/different_training_periods.py
@@ -1,0 +1,137 @@
+import numpy as np
+import calendar
+from datetime import date
+import xarray as xr
+import warnings
+
+from typing import cast, Dict, Optional, Tuple, List
+
+from ..utils import minus_months
+from .base import _EngineerBase
+
+
+class _DifferentTrainingPeriodsEngineer(_EngineerBase):
+    name = "one_month_forecast"
+
+    def _train_test_split(
+        self,
+        ds: xr.Dataset,
+        test_years: List[int],
+        target_variable: str,
+        pred_months: int,
+        expected_length: Optional[int],
+    ) -> xr.Dataset:
+        """save the test data and return the training dataset"""
+
+        test_years.sort()
+
+        months = ds['time.month'].values
+
+        if ds['time.year'].min() == test_years[0]:
+            # if we have the FIRST year in our dataset as a test year
+            # then minimum target month should be `pred_months + 1`
+            # e.g. x = 1984 Jan/Feb/Mar, y = 1984 April
+            init_target_month = pred_months + months[0]
+        else:
+            init_target_month = 1
+
+        # for the first `year` calculate the xy_test dictionary and min date
+        xy_test, min_test_date = self._stratify_xy(
+            ds=ds,
+            year=test_years[0],
+            target_variable=target_variable,
+            target_month=init_target_month,
+            pred_months=pred_months,
+            expected_length=expected_length,
+        )
+
+        # the train_ds MUST BE from before minimum test date
+        train_dates = ds.time.values <= np.datetime64(str(min_test_date))
+        train_ds = ds.isel(time=train_dates)
+
+        # save the xy_test dictionary
+        if xy_test is not None:
+            self._save(
+                xy_test, year=test_years[0], month=1, dataset_type="test")
+
+        # each month in test_year produce an x,y pair for testing
+        for year in test_years:
+            for month in range(init_target_month, 13):
+                if year > test_years[0] or month > init_target_month:
+                    # prevents the initial test set from being recalculated
+                    xy_test, _ = self._stratify_xy(
+                        ds=ds,
+                        year=year,
+                        target_variable=target_variable,
+                        target_month=month,
+                        pred_months=pred_months,
+                        expected_length=expected_length,
+                    )
+                    if xy_test is not None:
+                        self._save(xy_test, year=year, month=month,
+                                   dataset_type="test")
+        return train_ds
+
+    @staticmethod
+    def _stratify_xy(
+        ds: xr.Dataset,
+        year: int,
+        target_variable: str,
+        target_month: int,
+        pred_months: int = 11,
+        expected_length: Optional[int] = 11,
+    ) -> Tuple[Optional[Dict[str, xr.Dataset]], date]:
+        """
+        Note: expected_length should be the same as pred_months when the timesteps
+        are monthly, but should be more if the timesteps are at shorter resolution
+        than monthly.
+        """
+
+        print(f"Generating data for year: {year}, target month: {target_month}")
+
+        max_date = date(year, target_month, calendar.monthrange(year, target_month)[-1])
+        mx_year, mx_month, max_train_date = minus_months(
+            year, target_month, diff_months=1
+        )
+        _, _, min_date = minus_months(mx_year, mx_month, diff_months=pred_months)
+
+        # `max_date` is the date to be predicted;
+        # `max_train_date` is one timestep before;
+        min_date_np = np.datetime64(str(min_date))
+        max_date_np = np.datetime64(str(max_date))
+        max_train_date_np = np.datetime64(str(max_train_date))
+
+        print(
+            f"Max date: {str(max_date)}, max input date: {str(max_train_date)}, "
+            f"min input date: {str(min_date)}"
+        )
+
+        # boolean array indexing the timestamps to filter `ds`
+        x = (ds.time.values > min_date_np) & (ds.time.values <= max_train_date_np)
+        y = (ds.time.values > max_train_date_np) & (ds.time.values <= max_date_np)
+
+        # only expect ONE y timestamp
+        if sum(y) != 1:
+            print(f"Wrong number of y values! Expected 1, got {sum(y)}; returning None")
+            return None, cast(date, max_train_date)
+
+        if expected_length is not None:
+            if sum(x) != expected_length:
+                print(f"Wrong number of x values! Got {sum(x)} Returning None")
+
+                return None, cast(date, max_train_date)
+
+        # filter the dataset
+        x_dataset = ds.isel(time=x)
+        y_dataset = ds.isel(time=y)[target_variable].to_dataset(name=target_variable)
+
+        if x_dataset.time.size != expected_length:
+            # catch the errors as we get closer to the MINIMUM year
+            warnings.warn(
+                "For the `nowcast` experiment we expect the\
+                number of timesteps to be: {pred_months}.\
+                Currently: {x_dataset.time.size}"
+            )
+            return None, cast(date, max_train_date)
+
+        return {"x": x_dataset, "y": y_dataset}, cast(date, max_train_date)

--- a/src/engineer/different_training_periods.py
+++ b/src/engineer/different_training_periods.py
@@ -1,17 +1,99 @@
 import numpy as np
+import pandas as pd
 import calendar
 from datetime import date
 import xarray as xr
 import warnings
+import pickle
 
-from typing import cast, Dict, Optional, Tuple, List
+from typing import cast, Dict, Optional, Tuple, List, Union
 
 from ..utils import minus_months
-from .base import _EngineerBase
+from .one_month_forecast import _OneMonthForecastEngineer
 
 
-class _DifferentTrainingPeriodsEngineer(_EngineerBase):
+class _DifferentTrainingPeriodsEngineer(_OneMonthForecastEngineer):
     name = "one_month_forecast"
+
+    @staticmethod
+    def check_data_leakage(
+        train_ds: xr.Dataset, xy_test: Dict[str, xr.Dataset]
+    ) -> None:
+        # CHECK DATA LEAKAGE
+        train_dts = [pd.to_datetime(t) for t in train_ds.time.values]
+        test_dt = pd.to_datetime(xy_test["y"].time.values)
+        assert test_dt not in train_dts, (
+            "Data Leakage!" f"{test_dt} found in train_ds datetimes: \n {train_ds}"
+        )
+
+    def engineer(
+        self,
+        test_year: Union[int, List[int]],
+        target_variable: str = "VHI",
+        pred_months: int = 12,
+        expected_length: Optional[int] = 12,
+        train_years: Optional[List[int]] = None,
+    ) -> None:
+
+        self._process_dynamic(
+            test_year, target_variable, pred_months, expected_length, train_years
+        )
+        if self.process_static:
+            self._process_static()
+
+    def _process_dynamic(
+        self,
+        test_year: Union[int, List[int]],
+        target_variable: str = "VHI",
+        pred_months: int = 12,
+        expected_length: Optional[int] = 12,
+        train_years: Optional[List[int]] = None,
+    ) -> None:
+        if expected_length is None:
+            warnings.warn(
+                "** `expected_length` is None. This means that \
+            missing data will not be skipped. Are you sure? **"
+            )
+
+        # read in all the data from interim/{var}_preprocessed
+        data = self._make_dataset(static=False)
+
+        # ensure test_year is List[int]
+        if type(test_year) is int:
+            test_year = [cast(int, test_year)]
+
+        # save test data (x, y) and return the train_ds (subset of `data`)
+        train_ds = self._train_test_split(
+            ds=data,
+            test_years=cast(List, test_year),
+            target_variable=target_variable,
+            pred_months=pred_months,
+            expected_length=expected_length,
+            train_years=train_years,
+        )
+        assert train_ds.time.shape[0] > 0, (
+            "Expect the train_ds to have" f"`time` dimension. \n{train_ds}"
+        )
+
+        if train_years is not None:
+            # select only the TRAINING years in train_years
+            ds_years = train_ds["time.year"].values
+            bool_train_years = [y in train_years for y in ds_years]
+            train_ds = train_ds.sel(time=bool_train_years)
+
+        normalization_values = self._calculate_normalization_values(train_ds)
+
+        # split train_ds into x, y for each year-month before `test_year` & save
+        self._stratify_training_data(
+            train_ds=train_ds,
+            target_variable=target_variable,
+            pred_months=pred_months,
+            expected_length=expected_length,
+        )
+
+        savepath = self.output_folder / "normalizing_dict.pkl"
+        with savepath.open("wb") as f:
+            pickle.dump(normalization_values, f)
 
     def _train_test_split(
         self,
@@ -20,14 +102,15 @@ class _DifferentTrainingPeriodsEngineer(_EngineerBase):
         target_variable: str,
         pred_months: int,
         expected_length: Optional[int],
+        train_years: Optional[List[int]] = None,
     ) -> xr.Dataset:
         """save the test data and return the training dataset"""
 
         test_years.sort()
 
-        months = ds['time.month'].values
+        months = ds["time.month"].values
 
-        if ds['time.year'].min() == test_years[0]:
+        if ds["time.year"].min() == test_years[0]:
             # if we have the FIRST year in our dataset as a test year
             # then minimum target month should be `pred_months + 1`
             # e.g. x = 1984 Jan/Feb/Mar, y = 1984 April
@@ -35,6 +118,7 @@ class _DifferentTrainingPeriodsEngineer(_EngineerBase):
         else:
             init_target_month = 1
 
+        # NOTE: the test year is
         # for the first `year` calculate the xy_test dictionary and min date
         xy_test, min_test_date = self._stratify_xy(
             ds=ds,
@@ -45,19 +129,31 @@ class _DifferentTrainingPeriodsEngineer(_EngineerBase):
             expected_length=expected_length,
         )
 
-        # the train_ds MUST BE from before minimum test date
-        train_dates = ds.time.values <= np.datetime64(str(min_test_date))
+        # NOTE: relax assumption that train_ds MUST BEFORE before test date
+        if train_years is None:
+            # get the years BEFORE the test_year
+            train_dates = ds.time.values <= np.datetime64(str(min_test_date))
+        else:
+            # train on the years defined
+            train_dates = [y in train_years for y in ds["time.year"]]
         train_ds = ds.isel(time=train_dates)
 
         # save the xy_test dictionary
         if xy_test is not None:
             self._save(
-                xy_test, year=test_years[0], month=1, dataset_type="test")
+                xy_test,
+                year=test_years[0],
+                month=init_target_month,
+                dataset_type="test",
+            )
+
+        # check for data leakage
+        self.check_data_leakage(train_ds, xy_test)
 
         # each month in test_year produce an x,y pair for testing
         for year in test_years:
             for month in range(init_target_month, 13):
-                if year > test_years[0] or month > init_target_month:
+                if month > init_target_month:
                     # prevents the initial test set from being recalculated
                     xy_test, _ = self._stratify_xy(
                         ds=ds,
@@ -68,70 +164,8 @@ class _DifferentTrainingPeriodsEngineer(_EngineerBase):
                         expected_length=expected_length,
                     )
                     if xy_test is not None:
-                        self._save(xy_test, year=year, month=month,
-                                   dataset_type="test")
+                        # check for data leakage
+                        self.check_data_leakage(train_ds, xy_test)
+
+                        self._save(xy_test, year=year, month=month, dataset_type="test")
         return train_ds
-
-    @staticmethod
-    def _stratify_xy(
-        ds: xr.Dataset,
-        year: int,
-        target_variable: str,
-        target_month: int,
-        pred_months: int = 11,
-        expected_length: Optional[int] = 11,
-    ) -> Tuple[Optional[Dict[str, xr.Dataset]], date]:
-        """
-        Note: expected_length should be the same as pred_months when the timesteps
-        are monthly, but should be more if the timesteps are at shorter resolution
-        than monthly.
-        """
-
-        print(f"Generating data for year: {year}, target month: {target_month}")
-
-        max_date = date(year, target_month, calendar.monthrange(year, target_month)[-1])
-        mx_year, mx_month, max_train_date = minus_months(
-            year, target_month, diff_months=1
-        )
-        _, _, min_date = minus_months(mx_year, mx_month, diff_months=pred_months)
-
-        # `max_date` is the date to be predicted;
-        # `max_train_date` is one timestep before;
-        min_date_np = np.datetime64(str(min_date))
-        max_date_np = np.datetime64(str(max_date))
-        max_train_date_np = np.datetime64(str(max_train_date))
-
-        print(
-            f"Max date: {str(max_date)}, max input date: {str(max_train_date)}, "
-            f"min input date: {str(min_date)}"
-        )
-
-        # boolean array indexing the timestamps to filter `ds`
-        x = (ds.time.values > min_date_np) & (ds.time.values <= max_train_date_np)
-        y = (ds.time.values > max_train_date_np) & (ds.time.values <= max_date_np)
-
-        # only expect ONE y timestamp
-        if sum(y) != 1:
-            print(f"Wrong number of y values! Expected 1, got {sum(y)}; returning None")
-            return None, cast(date, max_train_date)
-
-        if expected_length is not None:
-            if sum(x) != expected_length:
-                print(f"Wrong number of x values! Got {sum(x)} Returning None")
-
-                return None, cast(date, max_train_date)
-
-        # filter the dataset
-        x_dataset = ds.isel(time=x)
-        y_dataset = ds.isel(time=y)[target_variable].to_dataset(name=target_variable)
-
-        if x_dataset.time.size != expected_length:
-            # catch the errors as we get closer to the MINIMUM year
-            warnings.warn(
-                "For the `nowcast` experiment we expect the\
-                number of timesteps to be: {pred_months}.\
-                Currently: {x_dataset.time.size}"
-            )
-            return None, cast(date, max_train_date)
-
-        return {"x": x_dataset, "y": y_dataset}, cast(date, max_train_date)

--- a/tests/engineer/test_different_training_periods_engineer.py
+++ b/tests/engineer/test_different_training_periods_engineer.py
@@ -1,5 +1,5 @@
 import xarray as xr
-from src.engineer.different_training_periods import _DifferentTrainingPeriodsEngineer
+from src.engineer import Engineer
 from .test_base import _setup
 
 
@@ -21,14 +21,19 @@ class TestDifferentTrainingPeriodsEngineer:
 
     def test_stratify_with_non_sequential_test_train_years(self, tmp_path):
         _setup(tmp_path)
-        engineer = _DifferentTrainingPeriodsEngineer(tmp_path)
+        engineer = Engineer(
+            tmp_path,
+            experiment="one_month_forecast",
+            process_static=True,
+            different_training_periods=True,
+        )
 
         expected_length = 3
 
         # -------------------------------
         # test a first test/train option
         # -------------------------------
-        engineer._process_dynamic(
+        engineer.engineer_class._process_dynamic(
             test_year=[1999],
             target_variable="a",
             pred_months=3,
@@ -66,7 +71,7 @@ class TestDifferentTrainingPeriodsEngineer:
         # -------------------------------
         # test a second test/train option
         # -------------------------------
-        engineer._process_dynamic(
+        engineer.engineer_class._process_dynamic(
             test_year=[2000],
             target_variable="a",
             pred_months=3,

--- a/tests/engineer/test_different_training_periods_engineer.py
+++ b/tests/engineer/test_different_training_periods_engineer.py
@@ -1,0 +1,98 @@
+import xarray as xr
+from src.engineer.different_training_periods import _DifferentTrainingPeriodsEngineer
+from .test_base import _setup
+
+
+class TestDifferentTrainingPeriodsEngineer:
+    @staticmethod
+    def _check_folder(folder_path, expected_length):
+        y = xr.open_dataset(folder_path / "y.nc")
+        assert "b" not in set(y.variables), "Got unexpected variables in test set"
+
+        x = xr.open_dataset(folder_path / "x.nc")
+        for expected_var in {"a", "b"}:
+            assert expected_var in set(
+                x.variables
+            ), "Missing variables in testing input dataset"
+        assert (
+            len(x.time.values) == expected_length
+        ), "Wrong number of months in the test x dataset"
+        assert len(y.time.values) == 1, "Wrong number of months in test y dataset"
+
+    def test_stratify_with_non_sequential_test_train_years(self, tmp_path):
+        _setup(tmp_path)
+        engineer = _DifferentTrainingPeriodsEngineer(tmp_path)
+
+        expected_length = 3
+
+        # -------------------------------
+        # test a first test/train option
+        # -------------------------------
+        engineer._process_dynamic(
+            test_year=[1999],
+            target_variable="a",
+            pred_months=3,
+            expected_length=3,
+            train_years=[2000, 2001],
+        )
+
+        for month in range(4, 13):
+            # TEST DATA
+            # because our first year is 1999 (test_year) we can only test from
+            # the 4th month because we don't have any data from before that date
+            # so should X dates = {1999-01, 1999-02, 1999-03}, y dates = 1999-04
+            self._check_folder(
+                tmp_path / f"features/one_month_forecast/test/1999_{month}",
+                expected_length=expected_length,
+            )
+
+            # TRAIN DATA
+            # because of data leakage we should not have 1999-10, 1999-11, 1999-12 in
+            # train data. Therefore, to predict with 3 month lead times we need
+            # to train from y = 2000-04, X = {2000-01, 2000-02, 2000-03}
+            self._check_folder(
+                tmp_path / f"features/one_month_forecast/train/2000_{month}",
+                expected_length=expected_length,
+            )
+
+        for month in range(1, 13):
+            # TRAIN DATA
+            # for 2001 we should have all 12 of the months
+            self._check_folder(
+                tmp_path / f"features/one_month_forecast/train/2001_{month}",
+                expected_length=expected_length,
+            )
+
+        # -------------------------------
+        # test a second test/train option
+        # -------------------------------
+        engineer._process_dynamic(
+            test_year=[2000],
+            target_variable="a",
+            pred_months=3,
+            expected_length=3,
+            train_years=[1999, 2001],
+        )
+
+        for month in range(4, 13):
+            # TEST DATA
+            # because our first year is 2000 (test_year) we can only test from
+            # the 4th month because we don't have any data from before that date
+            # so should X dates = {2000-01, 2000-02, 2000-03}, y dates = 2000-04
+            self._check_folder(
+                tmp_path / f"features/one_month_forecast/test/2000_{month}",
+                expected_length=expected_length,
+            )
+
+            # TRAIN DATA
+            # because of data leakage we should not have 2000-10, 2000-11, 2000-12 in
+            # train data. Therefore, to predict with 3 month lead times we need
+            # to train from y = 2001-04, X = {2001-01, 2001-02, 2001-03}
+            self._check_folder(
+                tmp_path / f"features/one_month_forecast/train/2001_{month}",
+                expected_length=expected_length,
+            )
+            self._check_folder(
+                tmp_path / f"features/one_month_forecast/train/2000_{month}",
+                expected_length=expected_length,
+            )

--- a/tests/engineer/test_nowcast.py
+++ b/tests/engineer/test_nowcast.py
@@ -53,7 +53,7 @@ class TestNowcastEngineer:
         engineer = NowcastEngineer(tmp_path)
         train = engineer._train_test_split(
             dataset,
-            years=[2001],
+            test_years=[2001],
             target_variable="VHI",
             expected_length=11,
             pred_months=11,

--- a/tests/engineer/test_one_month_forecast.py
+++ b/tests/engineer/test_one_month_forecast.py
@@ -5,7 +5,7 @@ import xarray as xr
 import datetime as dt
 
 from src.engineer import _OneMonthForecastEngineer as OneMonthForecastEngineer
-
+from src.engineer.different_training_periods import _DifferentTrainingPeriodsEngineer
 from ..utils import _make_dataset
 from .test_base import _setup
 
@@ -53,7 +53,7 @@ class TestOneMonthForecastEngineer:
         engineer = OneMonthForecastEngineer(tmp_path)
         train = engineer._train_test_split(
             dataset,
-            years=[2001],
+            test_years=[2001],
             target_variable="VHI",
             pred_months=11,
             expected_length=11,
@@ -62,6 +62,21 @@ class TestOneMonthForecastEngineer:
         assert (
             train.time.values < np.datetime64("2001-01-01")
         ).all(), "Got years greater than the test year in the training set!"
+
+    @staticmethod
+    def _check_folder(folder_path, expected_length):
+        y = xr.open_dataset(folder_path / "y.nc")
+        assert "b" not in set(y.variables), "Got unexpected variables in test set"
+
+        x = xr.open_dataset(folder_path / "x.nc")
+        for expected_var in {"a", "b"}:
+            assert expected_var in set(
+                x.variables
+            ), "Missing variables in testing input dataset"
+        assert (
+            len(x.time.values) == expected_length
+        ), "Wrong number of months in the test x dataset"
+        assert len(y.time.values) == 1, "Wrong number of months in test y dataset"
 
     def test_engineer(self, tmp_path):
 
@@ -77,24 +92,16 @@ class TestOneMonthForecastEngineer:
             expected_length=expected_length,
         )
 
-        def check_folder(folder_path):
-            y = xr.open_dataset(folder_path / "y.nc")
-            assert "b" not in set(y.variables), "Got unexpected variables in test set"
-
-            x = xr.open_dataset(folder_path / "x.nc")
-            for expected_var in {"a", "b"}:
-                assert expected_var in set(
-                    x.variables
-                ), "Missing variables in testing input dataset"
-            assert (
-                len(x.time.values) == expected_length
-            ), "Wrong number of months in the test x dataset"
-            assert len(y.time.values) == 1, "Wrong number of months in test y dataset"
-
-        # check_folder(tmp_path / 'features/one_month_forecast/train/1999_12')
+        # _check_folder(tmp_path / 'features/one_month_forecast/train/1999_12')
         for month in range(1, 13):
-            check_folder(tmp_path / f"features/one_month_forecast/test/2001_{month}")
-            check_folder(tmp_path / f"features/one_month_forecast/train/2000_{month}")
+            self._check_folder(
+                tmp_path / f"features/one_month_forecast/test/2001_{month}",
+                expected_length=expected_length
+            )
+            self._check_folder(
+                tmp_path / f"features/one_month_forecast/train/2000_{month}",
+                expected_length=expected_length
+            )
 
         assert (
             len(list((tmp_path / "features/one_month_forecast/train").glob("2001_*")))
@@ -117,8 +124,12 @@ class TestOneMonthForecastEngineer:
     def test_stratify(self, tmp_path):
         _setup(tmp_path)
         engineer = OneMonthForecastEngineer(tmp_path)
-        ds_target, _, _ = _make_dataset(size=(20, 20))
-        ds_predictor, _, _ = _make_dataset(size=(20, 20))
+        ds_target, _, _ = _make_dataset(
+            size=(20, 20), start_date="1999-01-01", end_date="2001-12-31",
+        )
+        ds_predictor, _, _ = _make_dataset(
+            size=(20, 20), start_date="1999-01-01", end_date="2001-12-31",
+        )
         ds_predictor = ds_predictor.rename({"VHI": "predictor"})
         ds = ds_predictor.merge(ds_target)
 
@@ -141,3 +152,42 @@ class TestOneMonthForecastEngineer:
         ), f"\
         the max_train_date should be one month before the `target_month`,\
         `year`"
+
+    def test_stratify_with_non_sequential_test_train_years(self, tmp_path):
+        _setup(tmp_path)
+        engineer = _DifferentTrainingPeriodsEngineer(tmp_path)
+        ds_target, _, _ = _make_dataset(size=(20, 20))
+        ds_predictor, _, _ = _make_dataset(size=(20, 20))
+        ds_predictor = ds_predictor.rename({"VHI": "predictor"})
+        ds = ds_predictor.merge(ds_target)
+
+        expected_length = 3
+
+        engineer._process_dynamic(
+            test_year=[1999],
+            target_variable='a',
+            pred_months=3,
+            expected_length=3,
+            train_years=[2000]
+        )
+
+        for month in range(1, 13):
+            self._check_folder(
+                tmp_path / f"features/one_month_forecast/test/1999_{month}",
+                expected_length=expected_length
+            )
+            self._check_folder(
+                tmp_path / f"features/one_month_forecast/train/2001_{month}",
+                expected_length=expected_length
+            )
+
+        xy_dict, max_train_date = engineer._stratify_xy(
+            ds=ds,
+            year=1999,
+            target_variable="VHI",
+            target_month=4,
+            pred_months=3,
+            expected_length=3,
+        )
+
+        assert False

--- a/tests/engineer/test_one_month_forecast.py
+++ b/tests/engineer/test_one_month_forecast.py
@@ -5,7 +5,6 @@ import xarray as xr
 import datetime as dt
 
 from src.engineer import _OneMonthForecastEngineer as OneMonthForecastEngineer
-from src.engineer.different_training_periods import _DifferentTrainingPeriodsEngineer
 from ..utils import _make_dataset
 from .test_base import _setup
 
@@ -96,11 +95,11 @@ class TestOneMonthForecastEngineer:
         for month in range(1, 13):
             self._check_folder(
                 tmp_path / f"features/one_month_forecast/test/2001_{month}",
-                expected_length=expected_length
+                expected_length=expected_length,
             )
             self._check_folder(
                 tmp_path / f"features/one_month_forecast/train/2000_{month}",
-                expected_length=expected_length
+                expected_length=expected_length,
             )
 
         assert (
@@ -125,10 +124,10 @@ class TestOneMonthForecastEngineer:
         _setup(tmp_path)
         engineer = OneMonthForecastEngineer(tmp_path)
         ds_target, _, _ = _make_dataset(
-            size=(20, 20), start_date="1999-01-01", end_date="2001-12-31",
+            size=(20, 20), start_date="1999-01-01", end_date="2001-12-31"
         )
         ds_predictor, _, _ = _make_dataset(
-            size=(20, 20), start_date="1999-01-01", end_date="2001-12-31",
+            size=(20, 20), start_date="1999-01-01", end_date="2001-12-31"
         )
         ds_predictor = ds_predictor.rename({"VHI": "predictor"})
         ds = ds_predictor.merge(ds_target)
@@ -152,42 +151,3 @@ class TestOneMonthForecastEngineer:
         ), f"\
         the max_train_date should be one month before the `target_month`,\
         `year`"
-
-    def test_stratify_with_non_sequential_test_train_years(self, tmp_path):
-        _setup(tmp_path)
-        engineer = _DifferentTrainingPeriodsEngineer(tmp_path)
-        ds_target, _, _ = _make_dataset(size=(20, 20))
-        ds_predictor, _, _ = _make_dataset(size=(20, 20))
-        ds_predictor = ds_predictor.rename({"VHI": "predictor"})
-        ds = ds_predictor.merge(ds_target)
-
-        expected_length = 3
-
-        engineer._process_dynamic(
-            test_year=[1999],
-            target_variable='a',
-            pred_months=3,
-            expected_length=3,
-            train_years=[2000]
-        )
-
-        for month in range(1, 13):
-            self._check_folder(
-                tmp_path / f"features/one_month_forecast/test/1999_{month}",
-                expected_length=expected_length
-            )
-            self._check_folder(
-                tmp_path / f"features/one_month_forecast/train/2001_{month}",
-                expected_length=expected_length
-            )
-
-        xy_dict, max_train_date = engineer._stratify_xy(
-            ds=ds,
-            year=1999,
-            target_variable="VHI",
-            target_month=4,
-            pred_months=3,
-            expected_length=3,
-        )
-
-        assert False

--- a/tests/exporters/test_vhi.py
+++ b/tests/exporters/test_vhi.py
@@ -3,11 +3,7 @@ from unittest.mock import patch
 import pytest
 import re
 
-from src.exporters.vhi import (
-    VHIExporter,
-    _parse_time_from_filename,
-    make_filename,
-)
+from src.exporters.vhi import VHIExporter, _parse_time_from_filename, make_filename
 
 
 class TestVHIExporter:

--- a/tests/preprocess/test_srtm.py
+++ b/tests/preprocess/test_srtm.py
@@ -21,7 +21,7 @@ class TestSRTMPreprocessor:
         Band1 = np.random.randint(10, size=size)
 
         # make datast with correct attrs
-        ds = xr.Dataset({"crs": (dims, crs), "Band1": (dims, Band1),}, coords=coords)
+        ds = xr.Dataset({"crs": (dims, crs), "Band1": (dims, Band1)}, coords=coords)
         return ds
 
     def test_init(self, tmp_path):

--- a/tests/preprocess/test_vhi.py
+++ b/tests/preprocess/test_vhi.py
@@ -80,7 +80,7 @@ class TestVHIPreprocessor:
         raw_ds.to_netcdf(netcdf_filepath)
 
         # run the preprocessing steps
-        out = v._preprocess(netcdf_filepath.as_posix(), v.interim.as_posix(),)
+        out = v._preprocess(netcdf_filepath.as_posix(), v.interim.as_posix())
         expected = "STAR_VHP.G04.C07.NC_1981_8_31_kenya_VH.nc"
 
         assert out.name == expected, f"Expected: {expected} Got: {out.name}"
@@ -101,7 +101,7 @@ class TestVHIPreprocessor:
         subset_name = "kenya"
         t = pd.to_datetime("1981-08-31")
 
-        out_fname = VHIPreprocessor.create_filename(t, netcdf_filepath, subset_name,)
+        out_fname = VHIPreprocessor.create_filename(t, netcdf_filepath, subset_name)
 
         expected = "STAR_VHP.G04.C07.NC_1981_8_31_kenya_VH.nc"
         assert out_fname == expected, f"Expected: {expected}, got: {out_fname}"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -69,7 +69,7 @@ class CreateSHPFile:
 
     @staticmethod
     def create_demo_shapefile(filepath):
-        df = pd.DataFrame({"PROVID": [10, 20], "PROVINCE": ["NAIROBI", "KIAMBU"],})
+        df = pd.DataFrame({"PROVID": [10, 20], "PROVINCE": ["NAIROBI", "KIAMBU"]})
 
         p1 = Point((34.27795473150634, 0.3094489371060183))
         p2 = Point((35.45785473150634, 0.0118489371060182))


### PR DESCRIPTION
Create an Engineer class with the flexibility to freely choose train/test periods in any order.

* still checks for model leakage and (hopefully) avoids it
* creates a new `Engineer.engineer_class` the `_DifferentTrainingPeriodsEngineer`